### PR TITLE
Fix type hints so that `mypy --strict` checks pass

### DIFF
--- a/.github/workflows/do-checks-and-tests.yml
+++ b/.github/workflows/do-checks-and-tests.yml
@@ -15,7 +15,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox
       - name: Run linter
-        run: tox -e flake8,pylint_critical
+        run: tox -e flake8,pylint_critical,mypy_strict
 
   run-tests:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ local_scheme = "no-local-version"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = flake8,pylint_critical,py{37,38,39,310,311}-{oldest,latest}
+envlist = flake8,pylint_critical,mypy_strict,py{37,38,39,310,311}-{oldest,latest}
 isolated_build = True
 
 [testenv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,13 @@ deps =
 commands =
     pylint fauxdoc tests --ignore=__pycache__ --good-names=_,i,mn,mx,em
 
+[testenv:mypy_strict]
+basepython=python3.10
+deps =
+    mypy
+commands =
+    mypy src/fauxdoc --strict
+
 [testenv:build_package]
 basepython = python3.10
 skip_install = true

--- a/src/fauxdoc/__init__.py
+++ b/src/fauxdoc/__init__.py
@@ -1,7 +1,9 @@
 """Tools for generating fake data."""
-try:
+import sys
+
+if sys.version_info >= (3, 8):
     from importlib import metadata
-except (ImportError, ModuleNotFoundError):
+else:
     import importlib_metadata as metadata
 from . import dtrange
 from . import emitter

--- a/src/fauxdoc/dtrange.py
+++ b/src/fauxdoc/dtrange.py
@@ -1,7 +1,6 @@
 """Contains an implementation of a custom date/time range type."""
-from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta
-from typing import Optional, overload, Tuple, TypeVar, Union
+from typing import Optional, overload, Sequence, Tuple, TypeVar, Union
 
 
 DT = TypeVar('DT', date, datetime, time)

--- a/src/fauxdoc/dtrange.py
+++ b/src/fauxdoc/dtrange.py
@@ -3,8 +3,6 @@ from collections.abc import Sequence
 from datetime import date, datetime, time, timedelta
 from typing import Optional, overload, Tuple, TypeVar, Union
 
-from fauxdoc.typing import Number
-
 
 DT = TypeVar('DT', date, datetime, time)
 DTS = TypeVar('DTS', date, datetime, time, str)
@@ -291,7 +289,7 @@ def _parse_user_date(val: Union[DT, str], label: str) -> DT:
     )
 
 
-def dtrange(start: Union[DT, str], stop: Union[DT, str], step: Number = 1,
+def dtrange(start: Union[DT, str], stop: Union[DT, str], step: float = 1,
             step_unit: Optional[str] = None) -> DateOrTimeRange[DT]:
     """Constructs and returns a DateOrTimeRange object.
 

--- a/src/fauxdoc/emitter.py
+++ b/src/fauxdoc/emitter.py
@@ -1,11 +1,11 @@
 """Contains base Emitter classes, for emitting data values."""
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import Generic, List, Optional, Union
 
-from .typing import T
+from fauxdoc.typing import CT
 
 
-class Emitter(ABC):
+class Emitter(Generic[CT], ABC):
     """Abstract base class for defining emitter objects.
 
     Subclass this to implement an emitter object. At this level all you
@@ -63,7 +63,7 @@ class Emitter(ABC):
             f"{'' if self.num_unique_values == 1 else 's'}."
         )
 
-    def __call__(self, number: Optional[int] = None) -> Union[T, List[T]]:
+    def __call__(self, number: Optional[int] = None) -> Union[CT, List[CT]]:
         """Emits one data value or a list of multiple values.
 
         Use the 'number' kwarg to control whether you get a single
@@ -94,9 +94,9 @@ class Emitter(ABC):
         return self.emit_many(number)
 
     @abstractmethod
-    def emit(self) -> T:
+    def emit(self) -> CT:
         """Return one data value."""
 
     @abstractmethod
-    def emit_many(self, number: int) -> List[T]:
+    def emit_many(self, number: int) -> List[CT]:
         """Return multiple data values, as a list."""

--- a/src/fauxdoc/emitter.py
+++ b/src/fauxdoc/emitter.py
@@ -1,6 +1,6 @@
 """Contains base Emitter classes, for emitting data values."""
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional, Union
+from typing import Generic, List, Optional, overload, Union
 
 from fauxdoc.typing import CT
 
@@ -37,7 +37,7 @@ class Emitter(Generic[CT], ABC):
         return False
 
     @property
-    def num_unique_values(self) -> Union[None, int]:
+    def num_unique_values(self) -> Optional[int]:
         """Returns an int, the number of unique values emittable.
 
         This number should be relative to the next `emit` call. If your
@@ -62,6 +62,14 @@ class Emitter(Generic[CT], ABC):
             f"{self.num_unique_values} possible selection"
             f"{'' if self.num_unique_values == 1 else 's'}."
         )
+
+    @overload
+    def __call__(self, number: None = None) -> CT:
+        ...
+
+    @overload
+    def __call__(self, number: int) -> List[CT]:
+        ...
 
     def __call__(self, number: Optional[int] = None) -> Union[CT, List[CT]]:
         """Emits one data value or a list of multiple values.

--- a/src/fauxdoc/emitters/choice.py
+++ b/src/fauxdoc/emitters/choice.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, List, Sequence
 from fauxdoc.emitter import Emitter
 from fauxdoc.mathtools import clamp, gaussian, poisson, weighted_shuffle
 from fauxdoc.mixins import RandomMixin, ItemsMixin
-from fauxdoc.typing import Number, T
+from fauxdoc.typing import T
 
 
 class Choice(RandomMixin, ItemsMixin[T], Emitter[T]):
@@ -54,7 +54,7 @@ class Choice(RandomMixin, ItemsMixin[T], Emitter[T]):
 
     def __init__(self,
                  items: Sequence[T],
-                 weights: Optional[Sequence[Number]] = None,
+                 weights: Optional[Sequence[float]] = None,
                  replace: bool = True,
                  replace_only_after_call: bool = False,
                  noun: str = '',
@@ -71,7 +71,7 @@ class Choice(RandomMixin, ItemsMixin[T], Emitter[T]):
             rng_seed: (Optional.) See `rng_seed` attribute.
         """
         self.weights = weights
-        self.cum_weights: Optional[List[Number]] = None
+        self.cum_weights: Optional[List[float]] = None
         self.replace = replace or replace_only_after_call
         self.replace_only_after_call = replace_only_after_call
         self.noun = noun
@@ -217,7 +217,7 @@ class Choice(RandomMixin, ItemsMixin[T], Emitter[T]):
 
 def poisson_choice(items: Sequence[T],
                    mu: int = 1,
-                   weight_floor: Number = 0,
+                   weight_floor: float = 0,
                    replace: bool = True,
                    replace_only_after_call: bool = False,
                    noun: str = '',
@@ -247,9 +247,9 @@ def poisson_choice(items: Sequence[T],
 
 
 def gaussian_choice(items: Sequence[T],
-                    mu: Number = 0,
-                    sigma: Number = 1,
-                    weight_floor: Number = 0,
+                    mu: float = 0,
+                    sigma: float = 1,
+                    weight_floor: float = 0,
                     replace: bool = True,
                     replace_only_after_call: bool = False,
                     noun: str = '',
@@ -284,7 +284,7 @@ def gaussian_choice(items: Sequence[T],
                   rng_seed)
 
 
-def chance(chance: Number, rng_seed: Any = None) -> Choice[bool]:
+def chance(chance: float, rng_seed: Any = None) -> Choice[bool]:
     """Returns a Choice emitter with a certain chance of emitting True.
 
     Args:

--- a/src/fauxdoc/emitters/choice.py
+++ b/src/fauxdoc/emitters/choice.py
@@ -8,7 +8,7 @@ from fauxdoc.mixins import RandomMixin, ItemsMixin
 from fauxdoc.typing import Number, T
 
 
-class Choice(RandomMixin, ItemsMixin, Emitter):
+class Choice(RandomMixin, ItemsMixin[T], Emitter[T]):
     """Class for making random selections, optionally with weighting.
 
     This covers any kind of random choice and implements the most
@@ -71,11 +71,11 @@ class Choice(RandomMixin, ItemsMixin, Emitter):
             rng_seed: (Optional.) See `rng_seed` attribute.
         """
         self.weights = weights
-        self.cum_weights = None
+        self.cum_weights: Optional[List[Number]] = None
         self.replace = replace or replace_only_after_call
         self.replace_only_after_call = replace_only_after_call
         self.noun = noun
-        self._shuffled = None
+        self._shuffled: List[T] = []
         super().__init__(items=items, rng_seed=rng_seed)
 
     def reset(self) -> None:
@@ -125,7 +125,7 @@ class Choice(RandomMixin, ItemsMixin, Emitter):
             # losing track of what has already been emitted.
             self._global_shuffle()
 
-    def _global_shuffle(self):
+    def _global_shuffle(self) -> None:
         weights = self.weights or [1] * len(self._items)
         self._shuffled = weighted_shuffle(self._items, weights, self.rng)
         self._shuffled_index = 0
@@ -165,7 +165,7 @@ class Choice(RandomMixin, ItemsMixin, Emitter):
         """
         return self._num_unique_items
 
-    def _choice_without_replacement(self, number: int):
+    def _choice_without_replacement(self, number: int) -> List[T]:
         """Makes choices without replacing items."""
         if number > self._num_unique_items:
             self.raise_uniqueness_violation(number)
@@ -186,7 +186,7 @@ class Choice(RandomMixin, ItemsMixin, Emitter):
         # One call without replacement, with weights.
         return weighted_shuffle(self._items, self.weights, self.rng, number)
 
-    def _choice_with_replacement(self, number: int):
+    def _choice_with_replacement(self, number: int) -> List[T]:
         """Makes non-unique choices (with replacement)."""
         if len(self._items) == 1:
             # No choice here.
@@ -221,7 +221,7 @@ def poisson_choice(items: Sequence[T],
                    replace: bool = True,
                    replace_only_after_call: bool = False,
                    noun: str = '',
-                   rng_seed: Any = None) -> Choice:
+                   rng_seed: Any = None) -> Choice[T]:
     """Returns a Choice emitter with a Poisson weight distribution.
 
     Args:
@@ -253,7 +253,7 @@ def gaussian_choice(items: Sequence[T],
                     replace: bool = True,
                     replace_only_after_call: bool = False,
                     noun: str = '',
-                    rng_seed: Any = None) -> None:
+                    rng_seed: Any = None) -> Choice[T]:
     """Returns a Choice emitter with a Gaussian weight distribution.
 
     Args:
@@ -284,7 +284,7 @@ def gaussian_choice(items: Sequence[T],
                   rng_seed)
 
 
-def chance(chance: Number, rng_seed: Any = None) -> None:
+def chance(chance: Number, rng_seed: Any = None) -> Choice[bool]:
     """Returns a Choice emitter with a certain chance of emitting True.
 
     Args:

--- a/src/fauxdoc/emitters/fixed.py
+++ b/src/fauxdoc/emitters/fixed.py
@@ -7,7 +7,7 @@ from fauxdoc.mixins import ItemsMixin
 from fauxdoc.typing import T
 
 
-class Static(ItemsMixin, Emitter):
+class Static(ItemsMixin[T], Emitter[T]):
     """Class for emitting static values.
 
     Attributes:
@@ -30,7 +30,7 @@ class Static(ItemsMixin, Emitter):
         return [self.value] * number
 
 
-class Iterative(Emitter):
+class Iterative(Emitter[T]):
     """Class for emitting values from an iterator.
 
     Iterative emitters are infinite and will restart from the
@@ -78,7 +78,7 @@ class Iterative(Emitter):
     """
 
     def __init__(self,
-                 iterator_factory: Callable[[], Iterator],
+                 iterator_factory: Callable[[], Iterator[T]],
                  reset_after_call: bool = False) -> None:
         """Inits a Iterative emitter.
 
@@ -91,11 +91,11 @@ class Iterative(Emitter):
         self.reset()
 
     @property
-    def iterator_factory(self) -> None:
+    def iterator_factory(self) -> Callable[[], Iterator[T]]:
         return self._iterator_factory
 
     @iterator_factory.setter
-    def iterator_factory(self, factory: Callable[[], Iterator]) -> None:
+    def iterator_factory(self, factory: Callable[[], Iterator[T]]) -> None:
         """Sets the iterator_factory property."""
         try:
             next(factory())
@@ -107,7 +107,7 @@ class Iterative(Emitter):
             )
         self._iterator_factory = factory
 
-    def _infinite_iterator(self):
+    def _infinite_iterator(self) -> Iterator[T]:
         """Returns an infinitely regenerating iterator."""
         while True:
             for item in self.iterator_factory():
@@ -136,7 +136,7 @@ class Iterative(Emitter):
         return ret_value
 
 
-class Sequential(ItemsMixin, Iterative):
+class Sequential(ItemsMixin[T], Iterative[T]):
     """Class for creating an Iterative emitter for a sequence.
 
     Although you can achieve this using a plain Iterative emitter:
@@ -153,7 +153,7 @@ class Sequential(ItemsMixin, Iterative):
     """
 
     def __init__(self,
-                 items: Sequence,
+                 items: Sequence[T],
                  reset_after_call: bool = False) -> None:
         """Inits a Sequential emitter instance.
 

--- a/src/fauxdoc/emitters/fromfields.py
+++ b/src/fauxdoc/emitters/fromfields.py
@@ -1,15 +1,13 @@
 """Contains emitters that use Field data to generate output."""
-from inspect import signature
 from typing import (
-    Any, Callable, Generic, List, Mapping, Optional, Sequence, Union
+    Any, Callable, Generic, List, Optional, Sequence, Union
 )
-from unittest.mock import call
 
 from fauxdoc.group import ObjectGroup
 from fauxdoc.emitter import Emitter
 from fauxdoc.emitters.wrappers import BoundWrapper
 from fauxdoc.mixins import RandomMixin
-from fauxdoc.typing import CT, FieldLike, FieldReturn, OutputT, SourceT, T
+from fauxdoc.typing import FieldLike, FieldReturn, OutputT, SourceT, T
 
 
 class SourceFieldGroup(ObjectGroup[FieldLike[T]]):
@@ -40,7 +38,10 @@ class SourceFieldGroup(ObjectGroup[FieldLike[T]]):
     def single_valued(self) -> bool:
         """True if there is one source field that returns one value."""
         if len(self) == 1:
-            return not self[0].multi_valued
+            # pylint doesn't seem to like it if we don't do something
+            # to tell it `self` is indexable, like wrapping `self` in
+            # `list`.
+            return not list(self)[0].multi_valued
         return False
 
 

--- a/src/fauxdoc/emitters/text.py
+++ b/src/fauxdoc/emitters/text.py
@@ -5,7 +5,7 @@ from fauxdoc.emitter import Emitter
 from fauxdoc.emitters import Static
 from fauxdoc.mathtools import clamp
 from fauxdoc.mixins import RandomWithChildrenMixin
-from fauxdoc.typing import IntEmitterLike, StrEmitterLike
+from fauxdoc.typing import EmitterLike
 
 
 def make_alphabet(uchar_ranges: Optional[Sequence[Tuple[int, int]]] = None
@@ -79,8 +79,8 @@ class Word(RandomWithChildrenMixin, Emitter[str]):
     """
 
     def __init__(self,
-                 length_emitter: IntEmitterLike,
-                 alphabet_emitter: StrEmitterLike,
+                 length_emitter: EmitterLike[int],
+                 alphabet_emitter: EmitterLike[str],
                  rng_seed: Any = None) -> None:
         """Inits Word emitter with a length and alphabet emitter.
 
@@ -98,12 +98,12 @@ class Word(RandomWithChildrenMixin, Emitter[str]):
         self._update_num_unique_vals()
 
     @property
-    def length_emitter(self) -> IntEmitterLike:
+    def length_emitter(self) -> EmitterLike[int]:
         """Returns the 'length_emitter' attribute."""
         return self._length_emitter
 
     @property
-    def alphabet_emitter(self) -> StrEmitterLike:
+    def alphabet_emitter(self) -> EmitterLike[str]:
         """Returns the 'alphabet_emitter' attribute."""
         return self._alphabet_emitter
 
@@ -176,9 +176,9 @@ class Text(RandomWithChildrenMixin, Emitter[str]):
     """
 
     def __init__(self,
-                 numwords_emitter: IntEmitterLike,
-                 word_emitter: StrEmitterLike,
-                 sep_emitter: Optional[StrEmitterLike] = None,
+                 numwords_emitter: EmitterLike[int],
+                 word_emitter: EmitterLike[str],
+                 sep_emitter: Optional[EmitterLike[str]] = None,
                  rng_seed: Any = None) -> None:
         """Inits TextEmitter with word, separator, and text settings.
 
@@ -200,17 +200,17 @@ class Text(RandomWithChildrenMixin, Emitter[str]):
         self._update_num_unique_vals()
 
     @property
-    def numwords_emitter(self) -> IntEmitterLike:
+    def numwords_emitter(self) -> EmitterLike[int]:
         """Returns the 'numwords_emitter' attribute."""
         return self._numwords_emitter
 
     @property
-    def word_emitter(self) -> StrEmitterLike:
+    def word_emitter(self) -> EmitterLike[str]:
         """Returns the 'word_emitter' attribute."""
         return self._word_emitter
 
     @property
-    def sep_emitter(self) -> StrEmitterLike:
+    def sep_emitter(self) -> EmitterLike[str]:
         """Returns the 'sep_emitter' attribute."""
         return self._sep_emitter
 

--- a/src/fauxdoc/emitters/wrappers.py
+++ b/src/fauxdoc/emitters/wrappers.py
@@ -15,11 +15,7 @@ purpose wrapper functions to do generic data conversions instead of
 hard-coding them in each and every class that might need them.
 """
 from inspect import signature, Signature
-import random
-from typing import (
-    Any, Callable, Dict, Generic, List, Mapping, Optional, Sequence, Tuple,
-    TypeVar, Union
-)
+from typing import Any, Callable, Generic, List, Mapping, Optional
 from unittest.mock import call
 
 from fauxdoc.emitter import Emitter

--- a/src/fauxdoc/emitters/wrappers.py
+++ b/src/fauxdoc/emitters/wrappers.py
@@ -1,35 +1,141 @@
-"""Contains emitters that wrap other emitters."""
-from inspect import signature
-from typing import Any, Callable, List, Mapping, Optional, Sequence
+"""Contains emitters that wrap other emitters.
+
+Wrapping an emitter lets you easily convert the output of an existing
+emitter without having to create a whole new class. This can be useful
+for simple operations like data conversion: the user initializes a new
+WrapOne or WrapMany emitter instance by supplying one (WrapOne) or more
+(WrapMany) source emitters plus a wrapper function that takes the
+emitted data and returns the modified value.
+
+Note that there is some overhead in wrapping one emitter with another.
+If your use case requires extremely high efficiency, creating your own
+Emitter classes that do what you need will be a bit more performant.
+However, the wrapper approach is more flexible: you can create general-
+purpose wrapper functions to do generic data conversions instead of
+hard-coding them in each and every class that might need them.
+"""
+from inspect import signature, Signature
+import random
+from typing import (
+    Any, Callable, Dict, Generic, List, Mapping, Optional, Sequence, Tuple,
+    TypeVar, Union
+)
 from unittest.mock import call
 
 from fauxdoc.emitter import Emitter
 from fauxdoc.mixins import RandomWithChildrenMixin
-from fauxdoc.typing import EmitterLikeCallable, T
+from fauxdoc.typing import EmitterLike, ImplementsRNG, OutputT, SourceT
 
 
-class Wrap(RandomWithChildrenMixin, Emitter):
-    """Abstract base class for creating wrapper emitters.
+class BoundWrapper(Generic[SourceT, OutputT]):
+    """Utility class for user-provided wrapper functions.
 
-    Wrapper emitters are useful for easily converting output of an
-    existing emitter without having to create a whole new class. This
-    can be useful for simple operations like data conversion: the user
-    initializes a new Wrap instance by supplying one or more source
-    emitters and a wrapper function that takes the emitted data and
-    returns the modified value.
+    Use this to encapsulate any user-provided wrapper callable that's
+    bound to an object that can provide RNG. Doing so adds a couple of
+    handy features to the callable:
 
-    Optionally, the wrapper may also take an additional 'rng' kwarg, if
-    it needs to generate random values. In this case the parent passes
-    its 'rng' attribute, ensuring your wrapper uses the correct seed,
-    etc.
+    - Automatic handling of RNG. If the user-provided callable includes
+      an `rng` kwarg in its signature, then calls to the BoundWrapper
+      instance automatically forward the `rng` attribute from the
+      `bound_to` object to the wrapped function. If not, they don't.
+      (This way, seeding and resetting RNG function as expected with
+      the wrapper.)
+    - Exposes the signature of the function via a `signature`
+      attribute.
+    - You can check that the user-provided wrapper function has the
+      expected signature by using the `try_mock_call` method.
 
-    Note that there is some overhead in wrapping one emitter with
-    another. If your use case requires extremely high efficiency,
-    creating your own Emitter classes that do what you need will be a
-    bit more performant. However, the wrapper approach is more
-    flexible: you can create general-purpose wrapper functions to do
-    generic data conversions instead of hard-coding it in each and
-    every class that might need it.
+    This frees the object that the wrapper is bound to from having to
+    implement these.
+
+    Attributes:
+        function: The function to wrap, called by calling this
+            BoundWrapper instance.
+        bound_to: The object that this wrapper is bound to. This object
+            must implement RNG (see the typing.ImplementsRNG protocol).
+            E.g., this will be the WrapOne or WrapMany instance that
+            instantiates this wrapper.
+        signature: An inspect.Signature object for the wrapped
+            function's signature. If your wrapped function is a built-
+            in method or type, then the signature cannot be determined,
+            and it will be None.
+        wants_rng: True if this wrapper has an `rng` kwarg in its call
+            signature and therefore expects an RNG (random.Random obj)
+            to be provided.
+    """
+
+    def __init__(self,
+                 function: Callable[..., OutputT],
+                 bound_to: ImplementsRNG) -> None:
+        """Inits a BoundWrapper object with the given function.
+
+        Args:
+            function: See 'function' attribute.
+            bound_to:
+        """
+        self.function = function
+        self.bound_to = bound_to
+        try:
+            self.signature: Optional[Signature] = signature(function)
+        except ValueError:
+            # We get a ValueError if we try to use builtin methods or
+            # types, like `str`.
+            self.signature = None
+            self.wants_rng = False
+        else:
+            self.wants_rng = 'rng' in self.signature.parameters
+
+    def __call__(self, *args: SourceT, **kwargs: SourceT) -> OutputT:
+        if self.wants_rng:
+            return self.function(*args, rng=self.bound_to.rng, **kwargs)
+        return self.function(*args, **kwargs)
+
+    def try_mock_call(self, *args: Any, **kwargs: Any) -> None:
+        """Tests the wrapped function signature by trying a mock call.
+
+        Use this to check the user-provided function and raise a useful
+        error if the call signature is not what's expected.
+
+        Args:
+            args: Sequence of positional args to pass to the function.
+            kwargs: Mapping of kwargs to pass to the function
+                (including `rng`, if applicable).
+
+        Returns:
+            None, if the call signature is fine.
+
+        Raises:
+            TypeError: If the mock call fails.
+        """
+        if self.wants_rng:
+            kwargs['rng'] = self.bound_to.rng
+        try:
+            if self.signature is None:
+                self.function(*args, **kwargs)
+            else:
+                self.signature.bind(*args, **kwargs)
+        except TypeError as e:
+            call_str = str(call(*args, **kwargs))[4:]
+            raise TypeError(
+                f'The callback provided to {type(self.bound_to).__name__} '
+                f'does not appear to have the correct signature. Attempting a '
+                f'mock call using {call_str} raised a TypeError: {e}.'
+            ) from e
+
+
+class Wrap(Generic[SourceT, OutputT], RandomWithChildrenMixin,
+           Emitter[OutputT]):
+    """(Deprecated) Abstract base class for creating wrapper emitters.
+
+    I've moved the specific functionality that the Wrap ABC *used* to
+    provide into the `BoundWrapper` class so that we can implement
+    WrapOne and WrapMany separately without a base class. (I think,
+    using `Wrap` as a base class and WrapOne and WrapMany having
+    different `wrapper` signatures violated Liskov. The new solution is
+    also a lot cleaner.)
+
+    Because `Wrap` is part of the v1.0.0 API, I'm deprecating it rather
+    than removing it. It will be removed in a future update.
 
     Attributes:
         emitters: (From RandomWithChildrenMixin.) This is a
@@ -43,193 +149,161 @@ class Wrap(RandomWithChildrenMixin, Emitter):
     """
 
     def __init__(self,
-                 source: Mapping[str, EmitterLikeCallable],
-                 wrapper: Callable,
-                 rng_seed: Optional[Any] = None):
+                 source: Mapping[str, EmitterLike[SourceT]],
+                 wrapper: Callable[..., OutputT],
+                 rng_seed: Any = None):
         """Inits a Wrap emitter with a source and a wrapper callable.
-
         Args:
             source: A dict that maps labels to wrapped source emitters,
                 used to populate the 'emitter' attribute.
             wrapper: See 'wrapper' attribute.
             rng_seed: See 'rng_seed' attribute.
         """
-        self.wrapper = wrapper
         super().__init__(children=source, rng_seed=rng_seed)
-
-    @property
-    def wrapper(self) -> Callable:
-        return self._wrapper
-
-    @wrapper.setter
-    def wrapper(self, wrapper: Callable) -> None:
-        """Sets the `wrapper` property.
-
-        This also looks for an 'rng' kwarg in the provided wrapper's
-        call signature and sets a private '_wrapper_wants_rng'
-        attribute.
-
-        Arguments:
-            wrapper: See 'wrapper' attribute.
-        """
-        try:
-            wrapsig = signature(wrapper)
-        except ValueError:
-            self._wrapper_wants_rng = False
-        else:
-            self._wrapper_wants_rng = 'rng' in wrapsig.parameters
-        self._wrapper = wrapper
-
-    def _raise_wrapper_call_error(self, error: TypeError, args: Sequence,
-                                  kwargs: Mapping) -> None:
-        """Raises a TypeError based on a failed wrapper call.
-
-        The intended use for this is to catch/raise a TypeError during
-        either of the emit methods if the wrapper call fails.
-        """
-        call_str = str(call(*args, **kwargs))[4:]
-        raise TypeError(
-            f'Trying to call ``self.wrapper{call_str}`` raised a TypeError: '
-            f'"{error}." (The signature for self.wrapper may not match what '
-            f'the ``{type(self).__name__}`` class expects.)'
-        ) from error
+        self.wrapper: BoundWrapper[SourceT, OutputT] = BoundWrapper(
+            wrapper, self
+        )
 
 
-class WrapOne(Wrap):
+class WrapOne(Generic[SourceT, OutputT], RandomWithChildrenMixin,
+              Emitter[OutputT]):
     """Emitter class for wrapping one other emitter.
 
-    Use this to create an emitter that converts values from one source
-    emitter. When you call __init__, provide the source emitter and a
-    wrapper function. The wrapper should take a value emitted by the
-    source and return the modified value.
+    Use this to create an emitter that converts the values produced by
+    a single source emitter to some other output value. When you call
+    __init__, provide the source emitter and a wrapper function.
+
+    The wrapper should take one value emitted by the source and return
+    the modified value. Optionally, the wrapper may also take an
+    additional 'rng' kwarg, if it needs to generate random values. In
+    that case the parent passes its 'rng' attribute, ensuring your
+    wrapper uses the correct seed, etc.
 
     E.g.:
         >>> from fauxdoc.emitters.fixed import Iterative
-        >>> from fauxdoc.emitters.wrappers import Wrap
-        >>> em = WrapOne(Iterative(lambda: itertools.count(), str))
+        >>> from fauxdoc.emitters.wrappers import WrapOne
+        >>> em = WrapOne(Iterative(lambda: itertools.count()), str)
         >>> em(5)
         ['0', '1', '2', '3', '4']
 
-    See superclass (Wrap) for more details.
-
     Attributes:
-        emitters: See superclass.
+        emitters: See mixins.ChildrenMixin.emitters.
         wrapper: A callable that takes one input value from the source
             emitter and returns a corresponding value. Optionally,
             it may also take an 'rng' kwarg.
-        rng: See superclass.
-        rng_seed: See superclass.
+        rng: See mixins.RandomMixin.rng.
+        rng_seed: See mixins.RandomMixin.rng_seed.
     """
 
     def __init__(self,
-                 source: EmitterLikeCallable,
-                 wrapper: Callable,
-                 rng_seed: Optional[Any] = None) -> None:
+                 source: EmitterLike[SourceT],
+                 wrapper: Callable[..., OutputT],
+                 rng_seed: Any = None) -> None:
         """Inits a WrapOne emitter with a source and wrapper callable.
 
         Args:
             source: The emitter to wrap.
             wrapper: See 'wrapper' attribute.
+            rng_seed: See 'rng_seed' attribute.
         """
-        super().__init__({'source': source}, wrapper, rng_seed)
-
-    def emit(self) -> T:
-        """Returns an emitted value, run through `self.wrapper`."""
-        kwargs = {'rng': self.rng} if self._wrapper_wants_rng else {}
-        args = (self._emitters['source'](),)
+        super().__init__(children={'source': source}, rng_seed=rng_seed)
+        self.wrapper: BoundWrapper[SourceT, OutputT] = BoundWrapper(
+            wrapper, self
+        )
         try:
-            return self._wrapper(*args, **kwargs)
-        except TypeError as e:
-            self._raise_wrapper_call_error(e, args, kwargs)
+            self.wrapper.try_mock_call(self._emitters['source']())
+        except TypeError:
+            raise
+        finally:
+            self.reset()
 
-    def emit_many(self, number: int) -> List[T]:
+    def emit(self) -> OutputT:
+        """Returns an emitted value, run through `self.wrapper`."""
+        return self.wrapper(self._emitters['source']())
+
+    def emit_many(self, number: int) -> List[OutputT]:
         """Returns a list of emitted, wrapped values.
 
         Args:
             number: See superclass (Emitter).
         """
-        emitted = self._emitters['source'](number)
-        kwargs = {'rng': self.rng} if self._wrapper_wants_rng else {}
-        try:
-            return [self._wrapper(v, **kwargs) for v in emitted]
-        except TypeError as e:
-            self._raise_wrapper_call_error(e, (emitted[0],), kwargs)
+        return [self.wrapper(v) for v in self._emitters['source'](number)]
 
 
-class WrapMany(Wrap):
+class WrapMany(Generic[SourceT, OutputT], RandomWithChildrenMixin,
+               Emitter[OutputT]):
     """Emitter class for wrapping multiple other emitters.
 
     Use this to create an emitter that combines or converts values from
-    multiple source emitters. When you call __init__, provide source
-    emitters in a dict plus a wrapper function. The wrapper should take
-    values emitted by the sources, using the dict keys as kwargs, and
-    return the modified value.
+    multiple source emitters. When you call __init__, provide your
+    source emitters (as a dict) and your wrapper function.
+
+    The wrapper should take the values emitted by the sources as kwargs
+    and return the modified value. Optionally, the wrapper may also
+    take an additional 'rng' kwarg, if it needs to generate random
+    values. In this case the parent passes its 'rng' attribute,
+    ensuring the wrapper uses the correct seed, etc.
 
     E.g.:
         >>> from fauxdoc.emitters.fixed import Sequential
-        >>> from fauxdoc.emitters.wrappers import Wrap
+        >>> from fauxdoc.emitters.wrappers import WrapMany
         >>> em = WrapMany({
         ...     'name': Sequential(['Susan', 'Alice', 'Bob', 'Terry']),
         ...     'greet': Sequential(['Hi!', 'Yes?', 'What?', 'Yo!']),
-        ... }, lambda name, greet: f'{name} says, "{greet}"')
+        ... }, lambda **kw: f'{kw['name']} says, "{kw['greet']}"')
         >>> em(4)
         ['Susan says, "Hi!"', 'Alice says, "Yes?"', 'Bob says, "What?"',
          'Terry says, "Yo!"']
 
-    See superclass (Wrap) for more details.
-
     Attributes:
-        emitters: See superclass.
+        emitters: See mixins.ChildrenMixin.emitters.
         wrapper: A callable that takes one kwarg from each source
             emitter, using the label from the 'emitters' ObjectMap as
             the kwarg name. Optionally, it may take an addition 'rng'
             kwarg. It should return a final value based on the source
             emitter values.
-        rng: See superclass.
-        rng_seed: See superclass.
+        rng: See mixins.RandomMixin.rng.
+        rng_seed: See mixins.RandomMixin.rng_seed.
     """
 
-    def emit(self) -> T:
+    def __init__(self,
+                 sources: Mapping[str, EmitterLike[SourceT]],
+                 wrapper: Callable[..., OutputT],
+                 rng_seed: Any = None) -> None:
+        """Inits a WrapMany emitter with source emitters and a wrapper.
+
+        Args:
+            sources: The emitters to wrap, as a dict that maps kwarg
+                names to emitters. The dict keys should correspond to
+                kwarg names in your wrapper.
+            wrapper: See 'wrapper' attribute.
+            rng_seed: See 'rng_seed' attribute.
+        """
+        super().__init__(children=sources, rng_seed=rng_seed)
+        self.wrapper: BoundWrapper[SourceT, OutputT] = BoundWrapper(
+            wrapper, self
+        )
+        kwargs = {k: v() for k, v in self._emitters.items()}
+        try:
+            self.wrapper.try_mock_call(**kwargs)
+        except TypeError:
+            raise
+        finally:
+            self.reset()
+
+    def emit(self) -> OutputT:
         """Returns an emitted value, run through `self.wrapper`."""
         kwargs = {k: em() for k, em in self._emitters.items()}
-        if self._wrapper_wants_rng:
-            kwargs['rng'] = self.rng
-        try:
-            return self._wrapper(**kwargs)
-        except TypeError as e:
-            self._raise_wrapper_call_error(e, [], kwargs)
+        return self.wrapper(**kwargs)
 
-    def _check_emit_many_typeerror(self, error: TypeError,
-                                   emitted_data: Sequence,
-                                   has_rng_kwarg: bool):
-        kwargs = {k: v[0] for k, v in emitted_data}
-        if has_rng_kwarg:
-            kwargs['rng'] = self.rng
-        try:
-            self._wrapper(**kwargs)
-        except TypeError as e:
-            self._raise_wrapper_call_error(e, [], kwargs)
-        raise error
-
-    def emit_many(self, number: int) -> List[T]:
+    def emit_many(self, number: int) -> List[OutputT]:
         """Returns a list of emitted, wrapped values.
 
         Args:
             number: See superclass (Emitter).
         """
         emdata = [(k, em(number)) for k, em in self._emitters.items()]
-        if self._wrapper_wants_rng:
-            try:
-                return [
-                    self._wrapper(rng=self.rng, **{k: v[i] for k, v in emdata})
-                    for i in range(number)
-                ]
-            except TypeError as e:
-                self._check_emit_many_typeerror(e, emdata, True)
-        try:
-            return [
-                self._wrapper(**{k: v[i] for k, v in emdata})
-                for i in range(number)
-            ]
-        except TypeError as e:
-            self._check_emit_many_typeerror(e, emdata, False)
+        return [
+            self.wrapper(**{k: v[i] for k, v in emdata})
+            for i in range(number)
+        ]

--- a/src/fauxdoc/group.py
+++ b/src/fauxdoc/group.py
@@ -1,10 +1,12 @@
 """Contains classes for grouping and operating on groups of objects."""
 from abc import ABC, abstractmethod
 from collections import OrderedDict, UserList
-from typing import Any, Mapping
+from typing import Any, Generic, Iterable, Mapping, TypeVar
+
+from fauxdoc.typing import T
 
 
-class GroupMixin(ABC):
+class GroupMixin(Generic[T], ABC):
     """Abstract base class for defining Group objects.
 
     This is implemented via ObjectGroup and ObjectMap, but could be
@@ -14,7 +16,7 @@ class GroupMixin(ABC):
 
     @property
     @abstractmethod
-    def objects_iterable(self):
+    def objects_iterable(self) -> Iterable[T]:
         """Returns an itereable for the objects in this group.
 
         Override this in your subclass to define how to iterate
@@ -55,7 +57,7 @@ class GroupMixin(ABC):
                     pass
 
 
-class ObjectGroup(GroupMixin, UserList):
+class ObjectGroup(GroupMixin[T], UserList[T]):
     """Class for operating on groups of similar objects (as a list).
 
     Use this instead of ObjectMap when you need your group to behave
@@ -67,7 +69,7 @@ class ObjectGroup(GroupMixin, UserList):
     skip them.
     """
 
-    def __init__(self, *objects: Any) -> None:
+    def __init__(self, *objects: T) -> None:
         """Inits an ObjectGroup with the given objects.
 
         Args:
@@ -78,12 +80,12 @@ class ObjectGroup(GroupMixin, UserList):
         super().__init__(objects)
 
     @property
-    def objects_iterable(self):
+    def objects_iterable(self) -> Iterable[T]:
         """Iterates through the objects in this group."""
         return self
 
 
-class ObjectMap(GroupMixin, OrderedDict):
+class ObjectMap(GroupMixin[T], OrderedDict[str, T]):
     """Class for operating on groups of similar objects (as a dict).
 
     Use this instead of ObjectGroup when you need your group to behave
@@ -95,7 +97,7 @@ class ObjectMap(GroupMixin, OrderedDict):
     skip them.
     """
 
-    def __init__(self, objects: Mapping) -> None:
+    def __init__(self, objects: Mapping[str, T]) -> None:
         """Inits an ObjectMap with the given objects.
 
         Args:
@@ -105,6 +107,6 @@ class ObjectMap(GroupMixin, OrderedDict):
         super().__init__(objects)
 
     @property
-    def objects_iterable(self):
+    def objects_iterable(self) -> Iterable[T]:
         """Iterates through the objects in this group."""
-        return self.values()
+        return list(self.values())

--- a/src/fauxdoc/group.py
+++ b/src/fauxdoc/group.py
@@ -1,9 +1,8 @@
 """Contains classes for grouping and operating on groups of objects."""
 from abc import ABC, abstractmethod
-from collections import OrderedDict, UserList
 from typing import Any, Generic, Iterable, Mapping
 
-from fauxdoc.typing import T
+from fauxdoc.typing import OrderedDict, T, UserList
 
 
 class GroupMixin(Generic[T], ABC):

--- a/src/fauxdoc/group.py
+++ b/src/fauxdoc/group.py
@@ -1,7 +1,7 @@
 """Contains classes for grouping and operating on groups of objects."""
 from abc import ABC, abstractmethod
 from collections import OrderedDict, UserList
-from typing import Any, Generic, Iterable, Mapping, TypeVar
+from typing import Any, Generic, Iterable, Mapping
 
 from fauxdoc.typing import T
 

--- a/src/fauxdoc/mathtools.py
+++ b/src/fauxdoc/mathtools.py
@@ -3,10 +3,10 @@ import math
 import random
 from typing import List, Optional, Sequence
 
-from fauxdoc.typing import F, Number, T
+from fauxdoc.typing import F, T
 
 
-def poisson(x: int, mu: Number = 1) -> float:
+def poisson(x: int, mu: float = 1) -> float:
     """Applies a poisson probability distribution function.
 
     Args:
@@ -22,7 +22,7 @@ def poisson(x: int, mu: Number = 1) -> float:
     return (mu ** x) * (math.exp(-1 * mu)) / math.factorial(x)
 
 
-def gaussian(x: Number, mu: Number = 0, sigma: Number = 1) -> float:
+def gaussian(x: float, mu: float = 0, sigma: float = 1) -> float:
     """Applies a gaussian probability density function.
 
     Args:
@@ -71,7 +71,7 @@ def clamp(number: F, mn: Optional[F] = None, mx: Optional[F] = None) -> F:
 
 
 def weighted_shuffle(items: Sequence[T],
-                     weights: Sequence[Number],
+                     weights: Sequence[float],
                      rng: random.Random = random.Random(),
                      number: Optional[int] = None) -> List[T]:
     """Returns a list of items randomly shuffled based on weights.
@@ -94,7 +94,7 @@ def weighted_shuffle(items: Sequence[T],
             the full length of `items`.
     """
     def _faster_for_low_k(items: Sequence[T],
-                          weights: Sequence[Number],
+                          weights: Sequence[float],
                           rng: random.Random,
                           k: int) -> List[T]:
         # I adapted this from https://stackoverflow.com/a/43649323.
@@ -119,7 +119,7 @@ def weighted_shuffle(items: Sequence[T],
         return sample
 
     def _faster_for_high_k(items: Sequence[T],
-                          weights: Sequence[Number],
+                          weights: Sequence[float],
                           rng: random.Random,
                           k: int) -> List[T]:
         # I adapted this from https://stackoverflow.com/a/20548895.

--- a/src/fauxdoc/mathtools.py
+++ b/src/fauxdoc/mathtools.py
@@ -119,9 +119,9 @@ def weighted_shuffle(items: Sequence[T],
         return sample
 
     def _faster_for_high_k(items: Sequence[T],
-                          weights: Sequence[float],
-                          rng: random.Random,
-                          k: int) -> List[T]:
+                           weights: Sequence[float],
+                           rng: random.Random,
+                           k: int) -> List[T]:
         # I adapted this from https://stackoverflow.com/a/20548895.
         # This is more of an actual shuffle: we create a randomized
         # score for each item based on weight, and then reverse sort

--- a/src/fauxdoc/mathtools.py
+++ b/src/fauxdoc/mathtools.py
@@ -3,7 +3,7 @@ import math
 import random
 from typing import List, Optional, Sequence
 
-from fauxdoc.typing import Number, T
+from fauxdoc.typing import F, Number, T
 
 
 def poisson(x: int, mu: Number = 1) -> float:
@@ -42,9 +42,7 @@ def gaussian(x: Number, mu: Number = 0, sigma: Number = 1) -> float:
     return term1 * term2
 
 
-def clamp(number: Number,
-          mn: Optional[Number] = None,
-          mx: Optional[Number] = None) -> Number:
+def clamp(number: F, mn: Optional[F] = None, mx: Optional[F] = None) -> F:
     """Limits a given number to a minimum and/or maximum value.
 
     Examples:

--- a/src/fauxdoc/mathtools.py
+++ b/src/fauxdoc/mathtools.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Sequence
 from fauxdoc.typing import Number, T
 
 
-def poisson(x: int, mu: Optional[Number] = 1) -> float:
+def poisson(x: int, mu: Number = 1) -> float:
     """Applies a poisson probability distribution function.
 
     Args:
@@ -22,9 +22,7 @@ def poisson(x: int, mu: Optional[Number] = 1) -> float:
     return (mu ** x) * (math.exp(-1 * mu)) / math.factorial(x)
 
 
-def gaussian(x: Number,
-             mu: Optional[Number] = 0,
-             sigma: Optional[Number] = 1) -> float:
+def gaussian(x: Number, mu: Number = 0, sigma: Number = 1) -> float:
     """Applies a gaussian probability density function.
 
     Args:
@@ -76,7 +74,7 @@ def clamp(number: Number,
 
 def weighted_shuffle(items: Sequence[T],
                      weights: Sequence[Number],
-                     rng: Optional[random.Random] = random.Random(),
+                     rng: random.Random = random.Random(),
                      number: Optional[int] = None) -> List[T]:
     """Returns a list of items randomly shuffled based on weights.
 
@@ -97,14 +95,17 @@ def weighted_shuffle(items: Sequence[T],
         number: (Optional.) The number of items you need. Defaults to
             the full length of `items`.
     """
-    def _faster_for_low_k(items, weights, rng, k):
+    def _faster_for_low_k(items: Sequence[T],
+                          weights: Sequence[Number],
+                          rng: random.Random,
+                          k: int) -> List[T]:
         # I adapted this from https://stackoverflow.com/a/43649323.
         # We iterate using random.choices to build our sample, removing
         # duplicate selections as we go. This brute force approach is
         # surprisingly fast for lower values of k.
         weights = list(weights)
         positions = range(len(items))
-        sample = []
+        sample: List[T] = []
         while True:
             needed = k - len(sample)
             if not needed:
@@ -119,7 +120,10 @@ def weighted_shuffle(items: Sequence[T],
                     sample.append(items[i])
         return sample
 
-    def _faster_for_high_k(items, weights, rng, k):
+    def _faster_for_high_k(items: Sequence[T],
+                          weights: Sequence[Number],
+                          rng: random.Random,
+                          k: int) -> List[T]:
         # I adapted this from https://stackoverflow.com/a/20548895.
         # This is more of an actual shuffle: we create a randomized
         # score for each item based on weight, and then reverse sort

--- a/src/fauxdoc/mixins.py
+++ b/src/fauxdoc/mixins.py
@@ -1,6 +1,6 @@
 """Contains mixin classes."""
 import random
-from typing import Any, Generic, List, Mapping, Sequence
+from typing import Any, Generic, Sequence
 
 from fauxdoc.group import ObjectMap
 from fauxdoc.typing import EmitterLike, T

--- a/src/fauxdoc/mixins.py
+++ b/src/fauxdoc/mixins.py
@@ -119,7 +119,9 @@ class ChildrenMixin:
                 __init__. Optionally, if you include 'children', then
                 that is used to populate the private '_emitters' attr.
         """
-        self._emitters = ObjectMap(kwargs.pop('children', {}))
+        self._emitters: ObjectMap[EmitterLike[Any]] = ObjectMap(
+            kwargs.pop('children', {})
+        )
         super().__init__(*args, **kwargs)
 
     @property

--- a/src/fauxdoc/profile.py
+++ b/src/fauxdoc/profile.py
@@ -4,9 +4,7 @@ from typing import Any, Dict, Generic, List, Optional, Union
 from fauxdoc.group import ObjectMap
 from fauxdoc.emitters.fixed import Static
 from fauxdoc.mixins import RandomMixin
-from fauxdoc.typing import (
-    BoolEmitterLike, EmitterLike, FieldLike, IntEmitterLike, T
-)
+from fauxdoc.typing import EmitterLike, FieldLike, T
 
 
 class Field(RandomMixin, Generic[T]):
@@ -74,8 +72,8 @@ class Field(RandomMixin, Generic[T]):
     def __init__(self,
                  name: str,
                  emitter: EmitterLike[T],
-                 repeat: Optional[IntEmitterLike] = None,
-                 gate: Optional[BoolEmitterLike] = None,
+                 repeat: Optional[EmitterLike[int]] = None,
+                 gate: Optional[EmitterLike[bool]] = None,
                  hide: bool = False,
                  rng_seed: Any = None) -> None:
         """Inits a Field instance.

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -1,7 +1,7 @@
 """Contains constants/variables/etc. used for type hinting."""
 import random
 import sys
-from typing import Any, List, Optional, TypeVar, Union
+from typing import Any, List, Optional, overload, TypeVar, Union
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
@@ -20,10 +20,26 @@ OutputT = TypeVar('OutputT', covariant=True)
 
 # Protocols defined here.
 
-class EmitterLike(Protocol[CT]):
+class EmitterLike(Protocol[T]):
     """Is like an emitter.Emitter object."""
 
-    def __call__(self, number: Optional[int] = None) -> Union[CT, List[CT]]:
+    @property
+    def num_unique_values(self) -> Optional[int]:
+        ...
+
+    @property
+    def emits_unique_values(self) -> bool:
+        ...
+
+    @overload
+    def __call__(self, number: None = None) -> T:
+        ...
+
+    @overload
+    def __call__(self, number: int) -> List[T]:
+        ...
+
+    def __call__(self, number: Optional[int] = None) -> Union[T, List[T]]:
         ...
 
     def reset(self) -> None:
@@ -44,7 +60,7 @@ class ImplementsRNG(Protocol):
         ...
 
 
-class RandomEmitterLike(ImplementsRNG, EmitterLike[CT]):
+class RandomEmitterLike(ImplementsRNG, EmitterLike[T]):
     """Is like an emitter.RandomEmitter object."""
 
 

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -1,8 +1,7 @@
 """Contains constants/variables/etc. used for type hinting."""
+import random
 import sys
-from typing import (
-    Any, Callable, Generic, List, Optional, Sequence, TypeVar, Union
-)
+from typing import Any, List, Optional, TypeVar, Union
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
@@ -15,7 +14,8 @@ else:
 Number = Union[int, float]
 T = TypeVar('T')
 CT = TypeVar('CT', covariant=True)
-EmitterLikeCallable = Union[Callable[[int], Sequence[T]], 'EmitterLike']
+SourceT = TypeVar('SourceT', contravariant=True)
+OutputT = TypeVar('OutputT', covariant=True)
 
 
 # Protocols defined here.
@@ -30,33 +30,24 @@ class EmitterLike(Protocol[CT]):
         ...
 
 
-class BoolEmitterLike(EmitterLike[bool], Protocol):
-    """An emitter.Emitter-like object that emits booleans."""
-
-    def __call__(self,
-                 number: Optional[int] = None) -> Union[bool, List[bool]]:
-        ...
+BoolEmitterLike = EmitterLike[bool]
+IntEmitterLike = EmitterLike[int]
+StrEmitterLike = EmitterLike[str]
 
 
-class IntEmitterLike(EmitterLike[int], Protocol):
-    """An emitter.Emitter-like object that emits integers."""
+class ImplementsRNG(Protocol):
+    """Is a type that implements RNG."""
 
-    def __call__(self, number: Optional[int] = None) -> Union[int, List[int]]:
-        ...
-
-
-class StrEmitterLike(EmitterLike[str], Protocol):
-    """An emitter.Emitter-like object that emits strings."""
-
-    def __call__(self, number: Optional[int] = None) -> Union[str, List[str]]:
-        ...
-
-
-class RandomEmitterLike(EmitterLike[CT], Protocol):
-    """Is like an emitter.RandomEmitter object."""
+    rng: random.Random
 
     def seed(self, rng_seed: Any) -> None:
         ...
+
+
+class RandomEmitterLike(ImplementsRNG, EmitterLike[CT]):
+    """Is like an emitter.RandomEmitter object."""
+
+
 
 
 class FieldLike(Protocol):

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -11,11 +11,12 @@ else:
 
 # Type aliases defined here.
 
-Number = Union[int, float]
 T = TypeVar('T')
 CT = TypeVar('CT', covariant=True)
 SourceT = TypeVar('SourceT', contravariant=True)
 OutputT = TypeVar('OutputT', covariant=True)
+Number = Union[int, float]
+FieldReturn = Optional[Union[T, List[T]]]
 
 
 # Protocols defined here.
@@ -64,19 +65,19 @@ class RandomEmitterLike(ImplementsRNG, EmitterLike[T]):
     """Is like an emitter.RandomEmitter object."""
 
 
-
-
-class FieldLike(Protocol):
+class FieldLike(Protocol[CT]):
     """Is like a profile.Field object."""
 
     multi_valued: bool
+    name: str
+    hide: bool
 
-    def __call__(self) -> Any:
+    def __call__(self) -> FieldReturn[CT]:
         ...
 
     def reset(self) -> None:
         ...
 
     @property
-    def previous(self) -> Any:
+    def previous(self) -> FieldReturn[CT]:
         ...

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -16,7 +16,6 @@ F = TypeVar('F', bound=float)
 CT = TypeVar('CT', covariant=True)
 SourceT = TypeVar('SourceT', contravariant=True)
 OutputT = TypeVar('OutputT', covariant=True)
-Number = Union[int, float]
 FieldReturn = Optional[Union[T, List[T]]]
 
 

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -12,6 +12,7 @@ else:
 # Type aliases defined here.
 
 T = TypeVar('T')
+F = TypeVar('F', bound=float)
 CT = TypeVar('CT', covariant=True)
 SourceT = TypeVar('SourceT', contravariant=True)
 OutputT = TypeVar('OutputT', covariant=True)
@@ -61,7 +62,7 @@ class ImplementsRNG(Protocol):
         ...
 
 
-class RandomEmitterLike(ImplementsRNG, EmitterLike[T]):
+class RandomEmitterLike(ImplementsRNG, EmitterLike[T], Protocol[T]):
     """Is like an emitter.RandomEmitter object."""
 
 

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -1,9 +1,12 @@
 """Contains constants/variables/etc. used for type hinting."""
-from typing import Any, Callable, List, Optional, Sequence, TypeVar, Union
+import sys
+from typing import (
+    Any, Callable, Generic, List, Optional, Sequence, TypeVar, Union
+)
 
-try:
+if sys.version_info >= (3, 8):
     from typing import Protocol
-except ImportError:
+else:
     from typing_extensions import Protocol
 
 
@@ -11,22 +14,23 @@ except ImportError:
 
 Number = Union[int, float]
 T = TypeVar('T')
+CT = TypeVar('CT', covariant=True)
 EmitterLikeCallable = Union[Callable[[int], Sequence[T]], 'EmitterLike']
 
 
 # Protocols defined here.
 
-class EmitterLike(Protocol):
+class EmitterLike(Protocol[CT]):
     """Is like an emitter.Emitter object."""
 
-    def __call__(self, number: Optional[int] = None) -> Union[T, List[T]]:
+    def __call__(self, number: Optional[int] = None) -> Union[CT, List[CT]]:
         ...
 
     def reset(self) -> None:
         ...
 
 
-class BoolEmitterLike(EmitterLike, Protocol):
+class BoolEmitterLike(EmitterLike[bool], Protocol):
     """An emitter.Emitter-like object that emits booleans."""
 
     def __call__(self,
@@ -34,21 +38,21 @@ class BoolEmitterLike(EmitterLike, Protocol):
         ...
 
 
-class IntEmitterLike(EmitterLike, Protocol):
+class IntEmitterLike(EmitterLike[int], Protocol):
     """An emitter.Emitter-like object that emits integers."""
 
     def __call__(self, number: Optional[int] = None) -> Union[int, List[int]]:
         ...
 
 
-class StrEmitterLike(EmitterLike, Protocol):
+class StrEmitterLike(EmitterLike[str], Protocol):
     """An emitter.Emitter-like object that emits strings."""
 
     def __call__(self, number: Optional[int] = None) -> Union[str, List[str]]:
         ...
 
 
-class RandomEmitterLike(EmitterLike, Protocol):
+class RandomEmitterLike(EmitterLike[CT], Protocol):
     """Is like an emitter.RandomEmitter object."""
 
     def seed(self, rng_seed: Any) -> None:
@@ -60,12 +64,12 @@ class FieldLike(Protocol):
 
     multi_valued: bool
 
-    def __call__(self) -> T:
+    def __call__(self) -> Any:
         ...
 
     def reset(self) -> None:
         ...
 
     @property
-    def previous(self):
+    def previous(self) -> Any:
         ...

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -48,11 +48,6 @@ class EmitterLike(Protocol[T]):
         ...
 
 
-BoolEmitterLike = EmitterLike[bool]
-IntEmitterLike = EmitterLike[int]
-StrEmitterLike = EmitterLike[str]
-
-
 class ImplementsRNG(Protocol):
     """Is a type that implements RNG."""
 

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -1,12 +1,38 @@
 """Contains constants/variables/etc. used for type hinting."""
+import collections
 import random
 import sys
-from typing import Any, List, Optional, overload, TypeVar, Union
+from typing import Any, List, Optional, overload, TYPE_CHECKING, TypeVar, Union
 
 if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
     from typing_extensions import Protocol
+
+# For Python 3.7 and 3.8: standard library ABC classes (including
+# collections) aren't subscriptable and don't accept e.g. UserList[T]
+# at runtime, although they're required for type hints. This is the
+# fix.
+#
+# On Python >= 3.9, or during type checking, the collections versions
+# of these classes work.
+if sys.version_info >= (3, 9) or TYPE_CHECKING:
+    OrderedDict = collections.OrderedDict
+    UserList = collections.UserList
+
+# Otherwise, we need to hack it so these classes are subscriptable but
+# are otherwise identical.
+else:
+    class _OrderedDict:
+        def __getitem__(self, *args):
+            return collections.OrderedDict
+
+    class _UserList:
+        def __getitem__(self, *args):
+            return collections.UserList
+
+    OrderedDict = _OrderedDict()
+    UserList = _UserList()
 
 
 # Type aliases defined here.

--- a/tests/test_emitters_fromfields.py
+++ b/tests/test_emitters_fromfields.py
@@ -187,14 +187,13 @@ def test_basedonfields_emit(source, action, seed, expected):
 
 @pytest.mark.parametrize('source, action, has_rng, problem', [
     ([Field('test1', Static('test'))],
-     lambda: None, False, 'takes 0 positional arguments but 1 was given'),
+     lambda: None, False, 'too many positional arguments'),
     ([Field('test1', Static('test'))],
-     lambda rng: None, False, "got multiple values for argument 'rng'"),
+     lambda rng: None, False, "multiple values for argument 'rng'"),
     ([Field('test1', Static('test'))],
-     lambda rng, test1: None, False, "got multiple values for argument 'rng'"),
+     lambda rng, test1: None, False, "multiple values for argument 'rng'"),
     ([Field('test1', Static('test'))],
-     lambda v1, v2: None, False,
-     "missing 1 required positional argument: 'v2'"),
+     lambda v1, v2: None, False, "missing a required argument: 'v2'"),
     ([Field('test1', Static('test')),
       Field('test2', Static('test'))],
      lambda: None, False, "got an unexpected keyword argument 'test1'"),
@@ -203,7 +202,7 @@ def test_basedonfields_emit(source, action, seed, expected):
      lambda rng: None, False, "got an unexpected keyword argument 'test1'"),
     ([Field('test1', Static('test')),
       Field('test2', Static('test'))],
-     lambda v1, v2: None, False, "got an unexpected keyword argument 'test1'"),
+     lambda v1, v2: None, False, "missing a required argument: 'v1'"),
     ([Field('test1', Static('test')),
       Field('test2', Static('test'))],
      lambda test1, rng: None, False,
@@ -211,7 +210,7 @@ def test_basedonfields_emit(source, action, seed, expected):
     ([Field('test1', Static('test')),
       Field('test2', Static('test'))],
      lambda test1, test2, test3: None, False,
-     "missing 1 required positional argument: 'test3'"),
+     "missing a required argument: 'test3'"),
 ])
 def test_basedonfields_emit_bad_action_raises_error(source, action, has_rng,
                                                     problem):
@@ -222,13 +221,8 @@ def test_basedonfields_emit_bad_action_raises_error(source, action, has_rng,
         args = ''
         kwargs_sources = ', '.join([f"{f.name}='test'" for f in source])
     kwargs_rng = "rng=" if has_rng else ''
-    em = BasedOnFields(source, action)
-    _ = [field() for field in em.source]
-    with pytest.raises(TypeError) as excinfo_one:
-        _ = em()
-    with pytest.raises(TypeError) as excinfo_two:
-        _ = em(10)
-    for excinfo in (excinfo_one, excinfo_two):
-        err_msg = str(excinfo.value)
-        for blurb in (args, kwargs_sources, kwargs_rng, problem):
-            assert blurb in err_msg
+    with pytest.raises(TypeError) as excinfo:
+        em = BasedOnFields(source, action)
+    err_msg = str(excinfo.value)
+    for blurb in (args, kwargs_sources, kwargs_rng, problem):
+        assert blurb in err_msg

--- a/tests/test_emitters_fromfields.py
+++ b/tests/test_emitters_fromfields.py
@@ -222,7 +222,7 @@ def test_basedonfields_emit_bad_action_raises_error(source, action, has_rng,
         kwargs_sources = ', '.join([f"{f.name}='test'" for f in source])
     kwargs_rng = "rng=" if has_rng else ''
     with pytest.raises(TypeError) as excinfo:
-        em = BasedOnFields(source, action)
+        BasedOnFields(source, action)
     err_msg = str(excinfo.value)
     for blurb in (args, kwargs_sources, kwargs_rng, problem):
         assert blurb in err_msg

--- a/tests/test_emitters_wrappers.py
+++ b/tests/test_emitters_wrappers.py
@@ -81,7 +81,7 @@ def test_wrapone_emit_bad_wrapper_raises_error(wrapper, has_rng, problem):
     args = "'test'"
     kwargs = "rng=" if has_rng else ''
     with pytest.raises(TypeError) as excinfo:
-        em = WrapOne(Static('test'), wrapper)
+        WrapOne(Static('test'), wrapper)
     err_msg = str(excinfo.value)
     for blurb in (args, kwargs, problem):
         assert blurb in err_msg
@@ -153,7 +153,7 @@ def test_wrapmany_emit_bad_wrapper_raises_error(wrapper, has_rng, problem):
     kwargs_em = "a='test_a', b='test_b'"
     kwargs_rng = 'rng=' if has_rng else ''
     with pytest.raises(TypeError) as excinfo:
-        em = WrapMany({'a': Static('test_a'), 'b': Static('test_b')}, wrapper)
+        WrapMany({'a': Static('test_a'), 'b': Static('test_b')}, wrapper)
     err_msg = str(excinfo.value)
     for blurb in (kwargs_em, kwargs_rng, problem):
         assert blurb in err_msg


### PR DESCRIPTION
Type hints in `fauxdoc` v1.0 were preliminary and never actually checked with a type checker. For this PR, I went through with `mypy` and updated all the type hints so that `mypy --strict` checks pass. This required some refactoring for certain things, particularly `wrapper` emitters. (The public API is the same though.)

This also adds the `py.typed` marker so we can push out the next minor version and have working type hints.