### PR TITLE
Fix bugs in 1.1.0 release candidates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ repository = "https://github.com/unt-libraries/fauxdoc"
 [project.optional-dependencies]
 dev = [
     'pytest >= 6.2.4; python_version >= "3.10"',
-    'pytest >= 3.0.0; python_version < "3.10"'
+    'pytest >= 3.8.0; python_version < "3.10"'
 ]
 
 [tool.setuptools_scm]
@@ -66,13 +66,13 @@ commands =
 
 [testenv:py37-oldest]
 deps =
-    pytest==3.0.0
+    pytest==3.8.0
     typing_extensions==3.6.5
     importlib_metadata==2.0.0
 
 [testenv:py{38,39}-oldest]
 deps =
-    pytest==3.0.0
+    pytest==3.8.0
 
 [testenv:py{310,311}-oldest]
 deps =

--- a/src/fauxdoc/emitters/__init__.py
+++ b/src/fauxdoc/emitters/__init__.py
@@ -5,6 +5,10 @@ and then call repeatedly to generate output data. Each different type
 of emitter is built to create a specific type of data or be configured
 in a specific way.
 """
+from typing import Any
+
+from fauxdoc.warn import get_deprecated_attr
+
 from . import choice
 from .choice import chance, Choice, gaussian_choice, poisson_choice
 from . import fixed
@@ -14,12 +18,33 @@ from .fromfields import BasedOnFields, CopyFields
 from . import text
 from .text import make_alphabet, Text, Word
 from . import wrappers
-from .wrappers import Wrap, WrapOne, WrapMany
+from .wrappers import WrapOne, WrapMany, DEPRECATED as WRAPPERS_DEPRECATED
 
 
+# Below: Deprecated attributes don't get imported directly but are
+# imported dynamically via __getattr__. Pylint doesn't recognize this
+# and so complains about undefined variables in __all__, although star
+# imports still work. This error is suppressed.
 __all__ = [
     'choice', 'chance', 'Choice', 'gaussian_choice', 'poisson_choice',
     'fixed', 'Iterative', 'Sequential', 'Static', 'fromfields',
     'BasedOnFields', 'CopyFields', 'text', 'make_alphabet', 'Text',
-    'Word', 'wrappers', 'Wrap', 'WrapOne', 'WrapMany'
+    'Word', 'wrappers',
+    'Wrap',  # pylint: disable=undefined-all-variable
+    'WrapOne', 'WrapMany'
 ]
+
+
+ALL_DEPRECATED = {}
+ALL_DEPRECATED.update(WRAPPERS_DEPRECATED)
+
+
+def __getattr__(name: str) -> Any:
+    # Note: Because this appears in __init__.py, it ends up firing
+    # twice when you do a "from" import:
+    # "from fauxdoc.emitters import Wrap" raises two warnings instead
+    # of one. This is because the underlying mechanism does a `hasattr`
+    # call before accessing the attribute, which results in two calls.
+    # I don't think there is a way around this, but it doesn't hurt
+    # anything.
+    return get_deprecated_attr(name, __name__, 'module', ALL_DEPRECATED)

--- a/src/fauxdoc/emitters/__init__.py
+++ b/src/fauxdoc/emitters/__init__.py
@@ -5,7 +5,7 @@ and then call repeatedly to generate output data. Each different type
 of emitter is built to create a specific type of data or be configured
 in a specific way.
 """
-from typing import Any
+from typing import Any, List
 
 from fauxdoc.warn import get_deprecated_attr
 
@@ -35,8 +35,8 @@ __all__ = [
 ]
 
 
-ALL_DEPRECATED = {}
-ALL_DEPRECATED.update(WRAPPERS_DEPRECATED)
+DEPRECATED = {}
+DEPRECATED.update(WRAPPERS_DEPRECATED)
 
 
 def __getattr__(name: str) -> Any:
@@ -47,4 +47,8 @@ def __getattr__(name: str) -> Any:
     # call before accessing the attribute, which results in two calls.
     # I don't think there is a way around this, but it doesn't hurt
     # anything.
-    return get_deprecated_attr(name, __name__, 'module', ALL_DEPRECATED)
+    return get_deprecated_attr(name, __name__, 'module', DEPRECATED)
+
+
+def __dir__() -> List[str]:
+    return sorted(list(globals()) + list(DEPRECATED.keys()))

--- a/src/fauxdoc/emitters/choice.py
+++ b/src/fauxdoc/emitters/choice.py
@@ -129,7 +129,7 @@ class Choice(RandomMixin, ItemsMixin[T], Emitter[T]):
         self._cum_weights = cum_weights
 
     @property
-    def weights(self) -> Optional[Tuple[float, ...]]:
+    def weights(self) -> Optional[Sequence[float]]:
         """See the `weights` attribute."""
         return self._weights
 

--- a/src/fauxdoc/emitters/fixed.py
+++ b/src/fauxdoc/emitters/fixed.py
@@ -1,6 +1,7 @@
 """Contains functions and classes for implementing static emitters."""
 import itertools
 from typing import Callable, Iterator, List, Sequence
+import warnings
 
 from fauxdoc.emitter import Emitter
 from fauxdoc.mixins import ItemsMixin
@@ -276,7 +277,23 @@ class Sequential(ItemsMixin[T], Emitter[T]):
 
     @iterator_factory.setter
     def iterator_factory(self, factory: Callable[[], Iterator[T]]) -> None:
-        """Sets the iterator_factory property."""
+        """Sets the 'iterator_factory' attribute.
+
+        Setting 'iterator_factory' for Sequential emitters is now
+        deprecated, since it's not a very intuitive way to set the
+        emitted sequence, and it's impossible to ensure that the set
+        factory actually returns a sequence. From now on, if you need
+        to emit a different sequence, you should create a new
+        Sequential emitter instance. The 'iterator_factory' attribute
+        will become read-only in v2.0.0.
+        """
+        warnings.warn(
+            f'Setting {type(self).__name__}.iterator_factory is deprecated; '
+            f'in the next major version release this will be changed to a '
+            f'read-only attribute. If you need to emit a different sequence, '
+            f'please create a new {type(self).__name__} instance instead.',
+            DeprecationWarning
+        )
         Iterative.check_iter_factory(factory)
         self.check_seq_iter_factory(factory)
         self._items = tuple([item for item in factory()])

--- a/src/fauxdoc/emitters/wrappers.py
+++ b/src/fauxdoc/emitters/wrappers.py
@@ -21,6 +21,7 @@ from unittest.mock import call
 from fauxdoc.emitter import Emitter
 from fauxdoc.mixins import RandomWithChildrenMixin
 from fauxdoc.typing import EmitterLike, ImplementsRNG, OutputT, SourceT
+from fauxdoc.warn import get_deprecated_attr
 
 
 class BoundWrapper(Generic[SourceT, OutputT]):
@@ -153,8 +154,8 @@ class BoundWrapper(Generic[SourceT, OutputT]):
             ) from e
 
 
-class Wrap(Generic[SourceT, OutputT], RandomWithChildrenMixin,
-           Emitter[OutputT]):
+class _deprecated_Wrap(Generic[SourceT, OutputT], RandomWithChildrenMixin,
+                       Emitter[OutputT]):
     """(Deprecated) Abstract base class for creating wrapper emitters.
 
     I've moved the specific functionality that the Wrap ABC *used* to
@@ -165,7 +166,7 @@ class Wrap(Generic[SourceT, OutputT], RandomWithChildrenMixin,
     also a lot cleaner.)
 
     Because `Wrap` is part of the v1.0.0 API, I'm deprecating it rather
-    than removing it. It will be removed in a future update.
+    than removing it. It will be removed in the next major version.
 
     Attributes:
         emitters: (From RandomWithChildrenMixin.) This is a
@@ -397,3 +398,15 @@ class WrapMany(Generic[SourceT, OutputT], RandomWithChildrenMixin,
             self._wrapper(**{k: v[i] for k, v in emdata})
             for i in range(number)
         ]
+
+
+DEPRECATED = {
+    'Wrap': ('WrapOne or WrapMany', _deprecated_Wrap)
+}
+
+_deprecated_Wrap.__name__ = 'Wrap'
+_deprecated_Wrap.__qualname__ = 'Wrap'
+
+
+def __getattr__(name: str) -> Any:
+    return get_deprecated_attr(name, __name__, 'module', DEPRECATED)

--- a/src/fauxdoc/emitters/wrappers.py
+++ b/src/fauxdoc/emitters/wrappers.py
@@ -410,3 +410,7 @@ _deprecated_Wrap.__qualname__ = 'Wrap'
 
 def __getattr__(name: str) -> Any:
     return get_deprecated_attr(name, __name__, 'module', DEPRECATED)
+
+
+def __dir__() -> List[str]:
+    return sorted(list(globals()) + list(DEPRECATED.keys()))

--- a/src/fauxdoc/profile.py
+++ b/src/fauxdoc/profile.py
@@ -227,11 +227,11 @@ class Schema:
                 args. The `fields` attribute is generated from this.
                 Your field names become keys.
         """
-        self.fields: ObjectMap[FieldLike[Any]] = ObjectMap({})
+        self.fields = ObjectMap({})
         self.add_fields(*fields)
 
     @property
-    def fields(self) -> ObjectMap[FieldLike[Any]]:
+    def fields(self) -> Mapping[str, FieldLike[Any]]:
         """See 'fields' attribute."""
         return self._fields
 

--- a/src/fauxdoc/typing.py
+++ b/src/fauxdoc/typing.py
@@ -126,3 +126,7 @@ DEPRECATED = {
 
 def __getattr__(name: str) -> Any:
     return get_deprecated_attr(name, __name__, 'module', DEPRECATED)
+
+
+def __dir__() -> List[str]:
+    return sorted(list(globals()) + list(DEPRECATED.keys()))

--- a/src/fauxdoc/warn.py
+++ b/src/fauxdoc/warn.py
@@ -1,0 +1,59 @@
+"""Contains functions etc. related to deprecating parts of the package."""
+from typing import Any, Mapping, Optional, Tuple
+import warnings
+
+
+def get_deprecated_attr(attr_name: str,
+                        from_obj_name: str,
+                        from_type_name: str,
+                        deprecated: Mapping[str, Tuple[Optional[str], object]]
+                        ) -> Any:
+    """Gets a deprecated attribute and issues a deprecation warning.
+
+    Use this in an object or module's __getattr__ method to issue a
+    deprecation warning but still return the deprecated attribute.
+
+    Example: You want to deprecate example.OldClass in favor of
+    example.NewClass1 or example.NewClass2 and warn when someone
+    imports or uses example.OldClass.
+
+    First, rename example.OldClass -- e.g., example._OldClass. Then add
+    the following to the bottom of the 'example' module.
+
+    _OldClass.__name__ = 'OldClass'
+    _OldClass.__qualname__ = 'OldClass'
+    DEPR = { 'OldClass': ('NewClass1 or NewClass2', _OldClass) }
+    def __getattr__(name):
+        return get_deprecated_attr(name, __name__, 'module', DEPR)
+
+    Importing OldClass directly and accessing it via 'example.OldClass'
+    will continue to work (returning example._OldClass) -- but they
+    will both issue a deprecation warning telling the user to switch to
+    NewClass. (If there is no replacement for the deprecated attribute,
+    then in DEPR you could use { 'OldClass': (None, _OldClass) }
+    instead, and the warning will only mention the deprecation.)
+
+    Args:
+        attr_name: The name of the attribute the user is trying to get.
+        from_obj_name: The name of the object that should have the
+            attribute.
+        from_type_name: The name of the type of the object that should
+            have the attribute.
+        deprecated: A dictionary that maps deprecated attribute names
+            to tuples. Each tuple should contain two values: first, a
+            string containing the name or names of the replacement
+            attributes (or None if there is no replacement); second,
+            the deprecated attribute value to return.
+    """
+    if attr_name in deprecated:
+        new_name, attr_value = deprecated[attr_name]
+        replace_str = f' Please use {new_name} instead.' if new_name else ''
+        warnings.warn(
+            f'{from_obj_name}.{attr_name} is deprecated and will be removed '
+            f'in the next major version release.{replace_str}',
+            DeprecationWarning
+        )
+        return attr_value
+    raise AttributeError(
+        f'{from_type_name} {from_obj_name} has no attribute {attr_name!r}'
+    )

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -1,0 +1,112 @@
+"""Contains tests for package deprecation warnings."""
+from typing import Callable, Sequence, Union
+import warnings
+
+from fauxdoc.typing import EmitterLike, T
+
+
+def test_typing_number_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        from fauxdoc.typing import Number
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        msg = str(caught[0].message)
+        assert 'Number is deprecated' in msg
+        assert 'use float instead' in msg
+        assert Number == float
+
+
+def test_typing_emitterlikecallable_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        from fauxdoc.typing import EmitterLikeCallable
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        msg = str(caught[0].message)
+        assert 'EmitterLikeCallable is deprecated' in msg
+        assert 'use EmitterLike instead' in msg
+        assert EmitterLikeCallable == Union[
+            Callable[[int], Sequence[T]],
+            EmitterLike[T]
+        ]
+
+
+def test_typing_stremitterlike_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        from fauxdoc.typing import StrEmitterLike
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        msg = str(caught[0].message)
+        assert 'StrEmitterLike is deprecated' in msg
+        assert 'use EmitterLike[str] instead' in msg
+        assert StrEmitterLike == EmitterLike[str]
+
+
+def test_typing_intemitterlike_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        from fauxdoc.typing import IntEmitterLike
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        msg = str(caught[0].message)
+        assert 'IntEmitterLike is deprecated' in msg
+        assert 'use EmitterLike[int] instead' in msg
+        assert IntEmitterLike == EmitterLike[int]
+
+
+def test_typing_boolemitterlike_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        from fauxdoc.typing import BoolEmitterLike
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        msg = str(caught[0].message)
+        assert 'BoolEmitterLike is deprecated' in msg
+        assert 'use EmitterLike[bool] instead' in msg
+        assert BoolEmitterLike == EmitterLike[bool]
+
+
+def test_wrappers_wrap_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        from fauxdoc.emitters.wrappers import Wrap
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        msg = str(caught[0].message)
+        assert 'Wrap is deprecated' in msg
+        assert 'use WrapOne or WrapMany instead' in msg
+        assert Wrap.__name__ == 'Wrap'
+        assert Wrap.__qualname__ == 'Wrap'
+
+
+def test_emitters_wrap_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        # See emitters/__init__.py for more of an explanation, but --
+        # when we use "from" to import Wrap from emitters, we end up
+        # with two warnings. This is expected.
+        from fauxdoc.emitters import Wrap
+        assert len(caught) == 2
+
+        # If we import "emitters" and then access Wrap as an attribute,
+        # we just get the one warning.
+        from fauxdoc import emitters
+        _ = emitters.Wrap
+        assert len(caught) == 3
+
+        for warning in caught:
+            assert warning.category is DeprecationWarning
+            msg = str(warning.message)
+            assert 'Wrap is deprecated' in msg
+            assert 'use WrapOne or WrapMany instead' in msg
+        assert Wrap.__name__ == 'Wrap'
+        assert Wrap.__qualname__ == 'Wrap'
+
+
+def test_fixed_sequential_set_iteratorfactory_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        from fauxdoc.emitters.fixed import Sequential
+        assert len(caught) == 0
+        seq = Sequential([1, 2, 3])
+        assert len(caught) == 0
+        seq.iterator_factory = lambda: iter([4, 5, 6])
+        assert len(caught) == 1
+        assert caught[0].category is DeprecationWarning
+        msg = str(caught[0].message)
+        assert 'iterator_factory is deprecated' in msg
+        assert 'create a new Sequential instance instead' in msg

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,4 +1,4 @@
-"""Contains tests for package deprecation warnings."""
+"""Contains tests for deprecations."""
 from typing import Callable, Sequence, Union
 import warnings
 
@@ -63,6 +63,13 @@ def test_typing_boolemitterlike_warning():
         assert BoolEmitterLike == EmitterLike[bool]
 
 
+def test_typing_dir_contains_deprecated_things():
+    import fauxdoc
+    dir_listing = dir(fauxdoc.typing)
+    for item in fauxdoc.typing.DEPRECATED.keys():
+        assert item in dir_listing
+
+
 def test_wrappers_wrap_warning():
     with warnings.catch_warnings(record=True) as caught:
         from fauxdoc.emitters.wrappers import Wrap
@@ -73,6 +80,13 @@ def test_wrappers_wrap_warning():
         assert 'use WrapOne or WrapMany instead' in msg
         assert Wrap.__name__ == 'Wrap'
         assert Wrap.__qualname__ == 'Wrap'
+
+
+def test_wrappers_dir_contains_deprecated_things():
+    import fauxdoc
+    dir_listing = dir(fauxdoc.emitters.wrappers)
+    for item in fauxdoc.emitters.wrappers.DEPRECATED.keys():
+        assert item in dir_listing
 
 
 def test_emitters_wrap_warning():
@@ -96,6 +110,13 @@ def test_emitters_wrap_warning():
             assert 'use WrapOne or WrapMany instead' in msg
         assert Wrap.__name__ == 'Wrap'
         assert Wrap.__qualname__ == 'Wrap'
+
+
+def test_emitters_dir_contains_deprecated_things():
+    import fauxdoc
+    dir_listing = dir(fauxdoc.emitters)
+    for item in fauxdoc.emitters.DEPRECATED.keys():
+        assert item in dir_listing
 
 
 def test_fixed_sequential_set_iteratorfactory_warning():

--- a/tests/test_emitters_fixed.py
+++ b/tests/test_emitters_fixed.py
@@ -14,8 +14,40 @@ from fauxdoc.emitters import fixed
 ])
 def test_static_emit(value):
     em = fixed.Static(value)
+    assert em.value == value
     assert em() == value
     assert em(5) == [value] * 5
+
+
+def test_static_set_value():
+    em = fixed.Static('three')
+    em.value = 1
+    assert em() == 1
+    assert em.items == [1]
+
+
+def test_static_items_is_readonly():
+    em = fixed.Static('three')
+    with pytest.raises(AttributeError):
+        em.items = [1]
+
+
+def test_static_uniqueness_properties():
+    em = fixed.Static(1)
+    assert em.num_unique_values == 1
+    assert not em.emits_unique_values
+
+
+def test_static_emituniquevalues_is_readonly():
+    em = fixed.Static(1)
+    with pytest.raises(AttributeError):
+        em.emits_unique_values = True
+
+
+def test_static_numuniquevalues_is_readonly():
+    em = fixed.Static(1)
+    with pytest.raises(AttributeError):
+        em.num_unique_values = 5
 
 
 @pytest.mark.parametrize('iterator_factory, expected', [
@@ -36,14 +68,31 @@ def test_iterative_emit(iterator_factory, expected):
     assert [em() for _ in range(number)] == expected
 
 
-def test_iterative_empty_iterator_factory_raises_error():
+def test_iterative_set_iterator_factory():
+    em = fixed.Iterative(lambda: iter([1, 2, 3]))
+    _ = em()    # 1
+    _ = em(3)   # 2, 3, 1
+    em.iterator_factory = lambda: iter([4, 5, 6])
+    assert em() == 4
+    assert em(5) == [5, 6, 4, 5, 6]
+
+
+def test_iterative_empty_iterator_factory_raises_error_on_init():
     with pytest.raises(ValueError) as excinfo:
         _ = fixed.Iterative(lambda: iter([]))
     assert 'empty iterator' in str(excinfo.value)
 
 
+def test_iterative_empty_iterator_factory_raises_error_when_set():
+    em = fixed.Iterative(lambda: iter([1]))
+    with pytest.raises(ValueError) as excinfo:
+        em.iterator_factory = lambda: iter([])
+    assert 'empty iterator' in str(excinfo.value)
+
+
 def test_iterative_resetaftercall_isfalse_doesnot_reset_after_call():
     em = fixed.Iterative(lambda: iter([1, 2, 3]), reset_after_call=False)
+    assert not em.reset_after_call
     assert em(7) == [1, 2, 3, 1, 2, 3, 1]
     assert em(7) == [2, 3, 1, 2, 3, 1, 2]
     assert em() == 3
@@ -53,11 +102,57 @@ def test_iterative_resetaftercall_isfalse_doesnot_reset_after_call():
 
 def test_iterative_resetaftercall_istrue_resets_after_call():
     em = fixed.Iterative(lambda: iter([1, 2, 3]), reset_after_call=True)
+    assert em.reset_after_call
     assert em(7) == [1, 2, 3, 1, 2, 3, 1]
     assert em(7) == [1, 2, 3, 1, 2, 3, 1]
     assert em() == 1
     assert em() == 1
     assert em() == 1
+
+
+def test_iterative_change_resetaftercall():
+    em = fixed.Iterative(lambda: iter([1, 2, 3]), reset_after_call=False)
+    em.reset_after_call = True
+    assert em(4) == [1, 2, 3, 1]
+    assert em(2) == [1, 2]
+    assert em() == 1
+    em.reset_after_call = False
+    assert em(4) == [1, 2, 3, 1]
+    assert em(3) == [2, 3, 1]
+    assert em() == 2
+
+
+def test_iterative_iterator_is_readonly():
+    em = fixed.Iterative(lambda: iter([1]))
+    assert next(em.iterator) == 1
+    with pytest.raises(AttributeError):
+        em.iterator = iter([1])
+
+
+def test_iterative_reset():
+    em = fixed.Iterative(lambda: iter([1, 2, 3]), reset_after_call=False)
+    assert em() == 1
+    assert em() == 2
+    em.reset()
+    assert em() == 1
+
+
+def test_iterative_uniqueness_properties():
+    em = fixed.Iterative(lambda: iter([1, 2, 3]))
+    assert em.num_unique_values is None
+    assert not em.emits_unique_values
+
+
+def test_iterative_emituniquevalues_is_readonly():
+    em = fixed.Iterative(lambda: iter([1, 2, 3]))
+    with pytest.raises(AttributeError):
+        em.emits_unique_values = True
+
+
+def test_iterative_numuniquevalues_is_readonly():
+    em = fixed.Iterative(lambda: iter([1, 2, 3]))
+    with pytest.raises(AttributeError):
+        em.num_unique_values = 5
 
 
 @pytest.mark.parametrize('sequence, expected', [
@@ -69,9 +164,29 @@ def test_iterative_resetaftercall_istrue_resets_after_call():
 def test_sequential_emit(sequence, expected):
     em = fixed.Sequential(sequence)
     number = len(expected)
+    assert em.items == sequence
     assert em(number) == expected
     em.reset()
     assert [em() for _ in range(number)] == expected
+
+
+def test_sequential_set_iterator_factory():
+    em = fixed.Sequential([1, 2])
+    _ = em()    # 1
+    _ = em(2)   # 2, 1
+    em.iterator_factory = lambda: iter([4, 5, 6])
+    assert em.items == (4, 5, 6)
+    assert em.num_unique_values == 3
+    assert em() == 4
+    assert em(5) == [5, 6, 4, 5, 6]
+
+
+def test_sequential_set_nonseq_iterator_factory_raises_error():
+    em = fixed.Sequential([1, 2, 3])
+    _ = em()
+    with pytest.raises(ValueError) as excinfo:
+        em.iterator_factory = lambda: itertools.count()
+    assert 'sequence iterator' in str(excinfo.value)
 
 
 @pytest.mark.parametrize('sequence, expected', [
@@ -88,7 +203,7 @@ def test_sequential_uniqueness_properties(sequence, expected):
 def test_sequential_empty_iterator_factory_raises_error():
     with pytest.raises(ValueError) as excinfo:
         _ = fixed.Sequential([])
-    assert 'empty iterator' in str(excinfo.value)
+    assert 'cannot be empty' in str(excinfo.value)
 
 
 def test_sequential_resetaftercall_isfalse_doesnot_reset_after_call():

--- a/tests/test_emitters_fixed.py
+++ b/tests/test_emitters_fixed.py
@@ -1,6 +1,7 @@
 """Contains tests for fauxdoc.emitters.fixed."""
 import itertools
 import pytest
+import warnings
 
 from fauxdoc.emitters import fixed
 
@@ -174,7 +175,9 @@ def test_sequential_set_iterator_factory():
     em = fixed.Sequential([1, 2])
     _ = em()    # 1
     _ = em(2)   # 2, 1
-    em.iterator_factory = lambda: iter([4, 5, 6])
+    # This will throw a deprecation warning, which we ignore here:
+    with warnings.catch_warnings(record=True):
+        em.iterator_factory = lambda: iter([4, 5, 6])
     assert em.items == (4, 5, 6)
     assert em.num_unique_values == 3
     assert em() == 4
@@ -185,7 +188,9 @@ def test_sequential_set_nonseq_iterator_factory_raises_error():
     em = fixed.Sequential([1, 2, 3])
     _ = em()
     with pytest.raises(ValueError) as excinfo:
-        em.iterator_factory = lambda: itertools.count()
+        # This also throws a deprecation warning, which we ignore here:
+        with warnings.catch_warnings(record=True):
+            em.iterator_factory = lambda: itertools.count()
     assert 'sequence iterator' in str(excinfo.value)
 
 

--- a/tests/test_emitters_fromfields.py
+++ b/tests/test_emitters_fromfields.py
@@ -192,6 +192,18 @@ def test_copyfields_singlevalued(source, expected):
     assert em.single_valued == expected
 
 
+def test_copyfields_multi_with_separator_not_singlevalued():
+    # Edge Case. The CopyFields `single_valued` attribute is based on
+    # the source data, not the output. A CopyFields emitter that is set
+    # to concatenate multiple values is not `single_valued`, even
+    # though it emits one string value.
+    em = CopyFields([
+        Field('test1', Static('one')),
+        Field('test2', Static('two')),
+    ], separator=' | ')
+    assert not em.single_valued
+
+
 @pytest.mark.parametrize('source, separator, expected', [
     # Single-field tests
     (Field('test', Static('Test Val')), None, 'Test Val'),

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -170,6 +170,8 @@ def test_field_multi_value_each_unique_violation(emitter_each_unique):
 
 @pytest.mark.parametrize('field, expected', [
     (Field('test', Static('test')), False),
+    (Field('test', Static(['test'])), False),
+    (Field('test', Static(['test1', 'test2'])), False),
     (Field('test', Static('test'), repeat=None), False),
     (Field('test', Static('test'), repeat=Static(None)), False),
     (Field('test', Static('test'), repeat=Static(1)), True),


### PR DESCRIPTION
Locally I tested the v1.1.0 release candidates against `solrbenchmark`, which uses `fauxdoc`, and I found a couple of subtle bugs that my refactoring introduced that `fauxdoc` tests didn't catch. (Since this is a minor version release, it should not break anything for projects using `fauxdoc`.) This PR fixes these problems, plus it adds tests and improves docstrings to clarify the areas where my own confusion led to mistakes.

## Standardize and clarify meaning of `multi_valued` for `Field` objects

A `Field` may be single-valued or multi-valued. If it can only output one atomic value, it's single-valued; if outputs atomic values in a list, then it's multi-valued. This is controlled by the `repeat_emitter` — any number of repetitions outputs a list. In other words — a Field instance **must** have a `repeat_emitter` that outputs None (`Static(None)`) to be considered single-valued.

```python
from fauxdoc.profile import Field
from fauxdoc.emitters import Static

field = Field('test', Static('atomic value'), repeat=None)
field()
# "atomic value"
field.multi_valued
# False

field = Field('test', Static('atomic value'), repeat=Static(3))
field()
# ["atomic value", "atomic value", "atomic value"]
field.multi_valued
# True
```

### Confusing edge case 1

If `repeat_emitter` is configured only to output 0 values or 1 value, the Field instance is still considered multi-valued (because the atomic values are nested inside a list).

```python
from fauxdoc.profile import Field
from fauxdoc.emitters import Static

field = Field('test', Static('atomic value'), repeat=Static(0))
field()
# []
field.multi_valued
# True

field = Field('test', Static('atomic value'), repeat=Static(1))
field()
# ["atomic value"]
field.multi_valued
# True
```

This is more intuitive if you consider a Field where the `repeat_emitter` allows 1 to N repetitions. Any given call to the Field instance may output one value, but the Field itself is multi-valued.

```python
from fauxdoc.profile import Field
from fauxdoc.emitters import Choice, Static

field = Field('test', Static('atomic value'), repeat=Choice(range(1, 3)))
field()
# ["atomic value", "atomic value"]
field()
# ["atomic value"]
field.multi_valued
# True
```

### Confusing edge case 2

You could configure a Field instance to use an emitter whose most atomic value is a list; in this case you'd have a single-valued Field that does emit a list. The multi-valued version of that Field would output a list of lists. In other words: what is an "atomic" value for a Field instance is relative to that Field's emitter.

```python
from fauxdoc.profile import Field
from fauxdoc.emitters import Static

field = Field('test', Static(['atomic', 'value']), repeat=None)
field()
# ["atomic",  "value"]
field.multi_valued
# False

field = Field('test', Static(['atomic value']), repeat=Static(3))
field()
# [["atomic", "value"], ["atomic", "value"], ["atomic", "value"]]
multi_valued_field.multi_valued
# True
```

## Standardize and clarify meaning of `single_valued` for `CopyFields` emitters

A `CopyFields` emitter copies the contents of one or more Field instances. In a multi-valued scenario, it can either condense multiple values into one string (using a separator character), or it can output multiple values as a list. A `CopyFields` emitter is considered multi-valued any time it's working with a list of values — if: 1) its source Field is multi-valued, or 2) it has a list of source fields.

```python
from fauxdoc.profile import Field
from fauxdoc.emitters import CopyFields, Static

field = Field('test', Static('value'))
em = CopyFields(field)
field()
em()
# "value"
em.single_valued
# True

field = Field('test', Static('value'), repeat=Static(2))
em = CopyFields(field)
field()
em()
# ["value", "value"]
em.single_valued
# False

field1 = Field('test1', Static('first value'))
field2 = Field('test2', Static('second value'))
em = CopyFields([field1, field2])
field1()
field2()
em()
# ["first value", "second value"]
em.single_valued
# False
```

### Confusing edge case 1

If the source arg used to initialize a `CopyFields` instance is a list of any kind, the `CopyFields` emitter is considered multi-valued, even if there is only one Field instance in the list.

```python
from fauxdoc.profile import Field
from fauxdoc.emitters import CopyFields, Static

field = Field('test', Static('value'))
em = CopyFields([field])
field()
em()
# ["value"]
em.single_valued
# False
```

### Confusing edge case 2

If a `CopyFields` emitter is set to concatenate multiple values into one string, it is still considered multi-valued. In other words — the `single_valued` attribute refers to the source data, not necessarily the final output.

```python
from fauxdoc.profile import Field
from fauxdoc.emitters import CopyFields, Static

field1 = Field('test1', Static('first value'))
field2 = Field('test2', Static('second value'))
em = CopyFields([field1, field2], separator=' | ')
field1()
field2()
em()
# "first value | second value"
em.single_valued
# False
```

## Classes with calculated attributes that are based on settable public attributes should update the calculated attributes when the public attributes change

This is a general lesson learned that resulted from a specific refactor, and I tried to go through and make sure I followed this advice in other similar situations as well.

Specifically: for classes that use `ChildrenMixin` or `RandomWithChildrenMixin` — "child" emitters are added to a dict-like `ObjectMap` on initialization, in a private `_emitters` attribute. The point of the `ObjectMap` is that it collects all of the child emitters into one place so that we can easily call shared methods (like `reset` and `seed`) all at once on the whole collection of emitters. Additionally, each child emitter may or may not need to be public. This is on a case-by-case basis. If one does, we can easily create a public attribute that references that child. However — if the public attribute is *settable*, then setting it better also set the appropriate value in `obj._emitters`.

This was the mistake I made with the `Field` class. `Field` child emitters (`emitter`, `repeat`, and `gate`) are all public attributes, and they are all settable. When adding type hints, I learned that the `_emitters` Mapping approach isn't necessarily very type-hint friendly because it's harder to add type hints for values in any kind of Mapping or dict-like structure. So when I refactored, I implemented the children as attributes first (which can be given explicit type hints) and then referenced those when the `_emitters` mapping was created. Something like this:

```python
class Field(EmitterLike[T]):
    def __init__(self, name: str, emitter: EmitterLike[T], repeat=None, gate=None):
        ...
        self.emitter: EmitterLike[T] = emitter
        self.gate_emitter: EmitterLike[bool] = gate or Static(True)
        self.repeat_emitter: EmitterLike[int] = repeat or Static(None)
        super().__init__(children={
            'emitter': self.emitter,
            'gate': self.gate_emitter,
            'repeat': self.repeat_emitter
        })
```

A `Field` would be initialized with the correct values, but changing e.g. `obj.emitter` would NOT also update `obj._emitters['emitter']`, which led to some surprising bugs in `solrbenchmark` where I had specific `Field` subclasses that dynamically change their emitter.

After exploring several other options to fix this (including custom descriptors), I settled back on a solution closer to what I originally had: each public emitter attribute is implemented using the `@property` decorator, including a setter, that just returns or sets the value in `obj._emitters`. Somehow, once I made it back around to this implementation, the type hints continued working correctly — so the initial refactor was never necessary in the first place.

