### PR TITLE
Add changelog and last-minute fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,108 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [v1.1.0](https://github.com/unt-libraries/fauxdoc/compare/v1.0.0...v1.1.0)
+
+Overview of what's new in this version:
+- `fauxdoc` is now fully typed and passes `mypy --strict` checks.
+- Much refactoring. Fixing type hints revealed some underlying issues, and I've applied fixes and changes while leaving the public API as intact as possible — see details below about what exactly has changed.
+- A small number of deprecations to be removed in v2. See details below.
+- Previously undefined behavior, mainly around instance attributes, has been defined, documented, and tested. Attributes that are not read-only now have defined behavior when they are set after object instantiation.
+
+### Added
+
+- New `mypy_strict` tox environment for running `mypy` tests.
+- A `py.typed` file to indicate that the package now has type hints.
+- New tox environments for testing a package built using `build_package` against a target Python version: `py37-test_built_package` through `py311-test_built_package`.
+- A new kwarg for initializing `fauxdoc.emitters.choice.Choice` instances: `cum_weights` can now be supplied, if needed. Note that you can only supply `weights` or `cum_weights` — not both. All previous args/kwargs still work as before.
+- A `fauxdoc.emitters.fromfields.SourceFieldGroup` class. This is a subtype of `fauxdoc.groups.ObjectGroup`, used in `fauxdoc.emitters.fromfield` emitters to represent groups of source fields. It now implements the `single_valued` property that was previously only a private attribute on the `fauxdoc.emitters.fromfields.CopyFields` class.
+- Additions to `fauxdoc.emitters.fromfields` emitters (`CopyFields` and `BasedOnFields`):
+    - A new **public** attribute, `single_valued`, for both `CopyFields` and `BasedOnFields`. This attribute was previously private.
+    - `set_source_fields` method, on `CopyFields` and `BasedOnFields` — used to set the `source` attribute from one or a list of `Field` instances. (You can set `source` directly, but that requires a `fauxdoc.emitters.fromfields.SourceFieldGroup` instance. This is just for convenience.)
+    - `set_action_function` method, on `BasedOnFields` — used to set the `action` attribute from a function. (You can set `action` directly, but that requires a `fauxdoc.emitters.wrappers.BoundWrapper` instance. This is just for convenience.)
+- Two new static methods on `fauxdoc.emitters.fixed.Iterative`, which move previously internal operations into utilities that can be used by external agents:
+    - `check_iter_factory` — validates that an iterator factory function/method does not return an empty iterator, and raises a ValueError if it does.
+    - `make_infinite_iter` — creates an iterator from an iterator factory that loops infinitely.
+- A new `check_seq_iter_factory` static method on `fauxdoc.emitters.fixed.Sequential` allows validating that an iterator factory function/method probably generates an iterator that iterates over a sequence.
+- A `fauxdoc.emitters.wrappers.BoundWrapper` class. Used to encapsulate a user-provided wrapper function, bind it to an object that provides RNG, and allow validating a given signature against the wrapper function's signature.
+- A `set_wrapper_function` method on `fauxdoc.emitters.wrappers.WrapOne` and `fauxdoc.emitters.wrappers.WrapMany` — used to set the `wrapper` attribute from a function or other callable. (You can set `wrapper` directly, but that requires a `fauxdoc.emitters.wrappers.BoundWrapper` instance. This is just for convenience.)
+- A new `set_fields` method, on `fauxdoc.profile.Schema` — used to set `fields` more naturally, without forcing the user to supply a `fauxdoc.groups.ObjectMap` instance. (You can still set `fields` directly, as an `ObjectMap`.)
+- A `fauxdoc.typing.ImplementsRNG` protocol, for representing types that implement an `rng` attribute and `seed` method — such as `Field`s and various emitters.
+- New `fauxdoc.typing.OrderedDict` and `fauxdoc.typing.UserList` types, to control for the fact that the `collections` versions of these types are not subscriptable in Python 3.7 and 3.8 (which is needed for type hints). For Python 3.7 and 3.8, a `__getitem__` method is monkey-patched onto `collections.OrderedDict` and `collections.UserList`, to make them subscriptable.
+- New type aliases in `fauxdoc.typing`:
+    - `F` — a TypeVar for float types.
+    - `CT` — general-purpose covariant TypeVar.
+    - `SourceT` — a contravariant TypeVar for e.g. callable arguments and other types that represent source data.
+    - `OutputT` — a covariant TypeVar for e.g. callable return values that represent output data.
+    - `FieldReturn` — represents the return type when calling `fauxdoc.profile.Field` instances.
+- A new `fauxdoc.warn` module, which contains a function (`get_deprecated_attr`) for injecting a deprecation warning when a user gets a deprecated module or object attribute. (It's called from the `__getattr__` method of the applicable module or object.)
+
+### Changed
+
+- The minimum `pytest` version for Python 3.7 through 3.9 has been bumped up from 3.0.0 to 3.8.0. This is to allow testing deprecation warnings.
+- Tox environment `build_package` no longer tries `pip install`ing the built package. It's assumed you'll use the new `*-test_built_package` environments to test the built package, which will of course have to install it.
+- On `fauxdoc.emitters.choice.Choice`, any sequences provided for the `weights` and `cum_weights` attributes are now cast to tuples on assignment so that they are immutable once assigned. (You can set a brand new sequence, but you cannot change individual elements.)
+- `fauxdoc.emitters.fromfields.BasedOnFields` no longer inherits from `fauxdoc.emitters.fromfields.CopyFields`. The shared functionality that `CopyFields` previously provided is now implemented as `fauxdoc.emitters.fromfields.SourceFieldGroup`, which is now used for the `source` attribute on instances of both classes. If you set `source` directly, you must now give it a `SourceFieldGroup` instance.
+- `fauxdoc.emitters.fromfields.BasedOnFields` now uses the `fauxdoc.emitters.wrappers.BoundWrapper` class for its `action` attribute. This moves all of the relevant functionality that was basically duplicated from the `wrappers` emitters out into the `BoundWrapper`. If you set `action` directly, you must now give it a `BoundWrapper` instance.
+- `fauxdoc.emitters.fromfields.BasedOnFields` now validates the expected call signature of the provided `action` function when it's first set, not later when it's first called, so that the user gets notified immediately if their `action` function is not configured correctly.
+- The `iterator` instance attribute of `fauxdoc.emitters.fixed.Iterative` and `fauxdoc.emitters.fixed.Sequential` is now a read-only property. It should never have been settable in the first place, as it's impossible to make this attribute settable in a way that makes any sense.
+- `fauxdoc.emitters.fixed.Sequential` no longer inherits from `fauxdoc.emitters.fixed.Iterative`. Much of the specific functionality that `Sequential` needed to use from `Iterative` has been moved into public methods on `Iterative`, which `Sequential` now calls directly.
+- `fauxdoc.emitters.wrappers.WrapOne` and `fauxdoc.emitters.wrappers.WrapMany` no longer inherit from `fauxdoc.emitters.wrappers.Wrap`. The shared functionality that the `Wrap` parent class provided is now implemented as `fauxdoc.emitters.wrappers.BoundWrapper`, which is now used for the `wrapper` attribute on instances of `Wrap`, `WrapOne`, and `WrapMany`. If you set `wrapper` directly, you must now give it a `BoundWrapper` instance.
+- Each of `fauxdoc.emitters.wrappers.WrapOne` and `fauxdoc.emitters.wrappers.WrapMany` now validates the expected call signature of the provided `wrapper` function when it's set, not later when it's first called, so that the user gets notified immediately if their `wrapper` function is not configured correctly.
+- `fauxdoc.profile.Field` now inherits from `fauxdoc.mixins.RandomWithChildrenMixin` instead of just `RandomMixin`. This moves the functionality related to setting, resetting, and seeding children emitters from `Field` into `RandomWithChildrenMixin`.
+- On `fauxdoc.profile.Field`, the `multi_valued` attribute is now read-only. This attribute should never have been settable, as it is a fully computed attribute (based on `repeat_emitter`).
+- On `fauxdoc.profile.Schema`, the `hidden_fields` and `public_fields` were already read-only, dynamic properties; now they are no longer even cached. They were of course never meant to be mutable — but now, if you try changing them as dictionaries, your changes will not be saved.
+- The `fauxdoc.typing.EmitterLike` protocol is now more robust. It's now generic, so you can for instance use `EmitterLike[int]` to indicate that an Emitter-like type emits `int`s. It now includes properties `num_unique_values` and `emits_unique_values`. And `__call__` is overloaded to show that passing None returns a single atomic value, while passing an integer returns a list of values.
+- The `fauxdoc.typing.RandomEmitterLike` protocol now inherits from both `ImplementsRNG` and `EmitterLike`, and it is now generic.
+- The `fauxdoc.typing.FieldLike` protocol is now generic.
+- Comparing a `fauxdoc.dtrange.DateOrTimeRange` instance to another type of object is explicitly not supported and returns `NotImplemented`.
+
+### Deprecated
+
+- `fauxdoc.emitters.fixed.Sequential.iterator_factory`: This is currently settable but will become read-only in the future. Instead of setting `iterator_factory` to change the sequence that a `Sequential` instance emits, you should create a new `Sequential` instance using the new sequence.
+- `fauxdoc.emitters.wrappers.Wrap`: Use `wrappers.WrapOne` or `WrapMany`.
+- `fauxdoc.emitters.Wrap`: Use `emitters.WrapOne` or `WrapMany`.
+- `fauxdoc.typing.BoolEmitterLike`: Use `EmitterLike[bool]`.
+- `fauxdoc.typing.EmitterLikeCallable`: Use `EmitterLike`.
+- `fauxdoc.typing.Number`: Use `float`.
+- `fauxdoc.typing.IntEmitterLike`: Use `EmitterLike[int]`.
+- `fauxdoc.typing.StrEmitterLike`: Use `EmitterLike[str]`.
+
+### Fixed
+
+- Many, many type hints throughout the package have been added or altered to resolve `mypy` errors. In some cases, specific function or method implementations have been tweaked to better accommodate added type hints.
+- Many docstrings that were missing or incomplete have been added or updated.
+- On `fauxdoc.emitters.choice.Choice` instances, setting either of the `weights` or `cum_weights` attributes now correctly updates object state. The provided list of weights or cumulative weights is validated to ensure it contains the same number of entries as there are `items`. Whichever "weights" attribute is set, the other is updated with the correct values. And, if the `replace` attribute is False, the global items shuffle is regenerated to reflect the new weights.
+- On `fauxdoc.emitters.choice.Choice` instances, setting either of the `replace` or `replace_only_after_call` attributes may update the other to ensure valid object state. I.e., if the latter is True then the former must be True; if the former is False then the latter must also be False. Additionally, when `replace` changes to False, the global items shuffle is regenerated to reflect the current object state.
+- On `fauxdoc.emitters.fixed.Static` instances, setting the `value` attribute now correctly updates the contents of the `items` attribute with the new value.
+- On `fauxdoc.emitters.fixed.Iterative` and `fauxdoc.emitters.fixed.Sequential` instances, setting the `iterator_factory` attribute now performs appropriate validation on the iterator that the factory makes and then correctly regenerates the `iterator` attribute. On `Sequential` instances, it also repopulates the `items` attribute using the contents of the new iterator.
+- During a call to `fauxdoc.emitters.text.Text`'s `emit_many` method, a private `_get_words_iterator` method is used to generate words from the `word_emitter`. When `word_emitter.replace_only_after_call` is True, then it attempts to generate a set of unique words for each text string. Previously, it based this on `word_emitter.num_unique_items`. This has been changed so that it bases this on `word_emitter.num_unique_values`. (The difference being that `num_unique_items` might include duplicate words in separate items, while `num_unique_values` only counts truly unique words.)
+- On `fauxdoc.profile.Schema`, `fields` is both settable _and_ mutable — i.e., you can add or modify fields simply by editing `fields` as you would any dictionary. The `hidden_fields` and `public_fields` attributes are now calculated fully dynamically, meaning these now automatically update when `fields` changes. Previously they did not.
+
+
+## [v1.0.0](https://github.com/unt-libraries/fauxdoc/releases/tag/v1.0.0) - 2022-11-02
+
+First public release.
+
+### Added
+
+- `fauxdoc.emitter` — Emitter abstract base class to be used for all data emitters. Provides basic interface for creating callable emitter objects, which can have different underlying methods for emitting one versus many values, provide information about whether or not they emit unique values, and provide the number of unique values they emit. Emitters output values when called.
+- `fauxdoc.group` and `fauxdoc.mixins` — Helper classes and mixins for creating emitters that use random-number generation, generate compound values using data from atomic children emitters, and emit values from a set sequence of items.
+- `fauxdoc.dtrange` — Tools for producing and working with ranges of `datetime.datetime` and `datetime.time` objects, including a simple `range`-like factory (`fauxdoc.dtrange.dtrange`).
+- `fauxdoc.mathtools` — Math-related utility functions. Includes functions for creating gaussian and poisson distributions, clamping a number to fit within a specific range, and randomly shuffling a list based on weights.
+- `fauxdoc.profile` — Classes for building complete data profiles from emitter instances: Schema and Field. A Schema contains a set of named Field instances and outputs a data record when called. Each Field encapsulates an emitter and can be set to control the chances that any value will be output along how many values are output, per data record.
+- `fauxdoc.emitters.choice` — Choice emitters, used to select random values. Provides an optimized implementation using optional weights and optional replacement. Also provides factory methods for creating choice emitters that use common weight distributions (poisson, gaussian).
+- `fauxdoc.emitters.fixed` — Fixed emitters, used for emitting predefined values: a single static value, values from an iterator, or values from a sequence.
+- `fauxdoc.emitters.text` — Emitters for generating randomized text-like strings, both single words and multi-word sentences.
+- `fauxdoc.emitters.fromfields` — Emitters whose output should be based on values already generated via other fields (in context of a schema). They may copy values directly or copy and then modify values.
+- `fauxdoc.emitters.wrappers` — Emitters that wrap other emitter instances in order to modify their output. For example, you may have an emitter that generates random datetime objects, and you might have several functions for converting your datetime objects to strings of various formats. You could easily create wrapper emitters that wrap your datetime emitter and use the conversion functions to generate formatted strings without having to create individual emitter classes to do this.
+- Preliminary type-hints, not (yet) tested via a type checker. They are therefore currently quite broken.
+- A modern `pyproject.toml`-based configuration plus support for Python 3.7, 3.8, 3.9, 3.10, and 3.11.
+
+### Changed
+
+- Just a historical note to say that this project originated from the UNT Libraries' catalog-api project, recent development of which has moved over to our private GitLab server. When we first pulled it into its own repository (also on our private GitLab), we named it `solrfixtures` and used Poetry to manage dependencies. Shortly before releasing v1.0.0, we renamed the project `fauxdoc`, moved it to GitHub, removed the reliance on Poetry (and standardized `pyproject.toml`), and implemented GitHub actions for CI. It has also been fully and completely refactored compared to its original form. It was never public until v1.0.0, so I'm not bothering documenting those changes here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [v1.1.0](https://github.com/unt-libraries/fauxdoc/compare/v1.0.0...v1.1.0)
+## [v1.1.0](https://github.com/unt-libraries/fauxdoc/compare/v1.0.0...v1.1.0) — 2023-02-27
 
 Overview of what's new in this version:
 - `fauxdoc` is now fully typed and passes `mypy --strict` checks.
@@ -15,8 +15,8 @@ Overview of what's new in this version:
 
 ### Added
 
-- New `mypy_strict` tox environment for running `mypy` tests.
 - A `py.typed` file to indicate that the package now has type hints.
+- New `mypy_strict` tox environment for running `mypy` tests.
 - New tox environments for testing a package built using `build_package` against a target Python version: `py37-test_built_package` through `py311-test_built_package`.
 - A new kwarg for initializing `fauxdoc.emitters.choice.Choice` instances: `cum_weights` can now be supplied, if needed. Note that you can only supply `weights` or `cum_weights` — not both. All previous args/kwargs still work as before.
 - A `fauxdoc.emitters.fromfields.SourceFieldGroup` class. This is a subtype of `fauxdoc.groups.ObjectGroup`, used in `fauxdoc.emitters.fromfield` emitters to represent groups of source fields. It now implements the `single_valued` property that was previously only a private attribute on the `fauxdoc.emitters.fromfields.CopyFields` class.
@@ -45,6 +45,7 @@ Overview of what's new in this version:
 
 - The minimum `pytest` version for Python 3.7 through 3.9 has been bumped up from 3.0.0 to 3.8.0. This is to allow testing deprecation warnings.
 - Tox environment `build_package` no longer tries `pip install`ing the built package. It's assumed you'll use the new `*-test_built_package` environments to test the built package, which will of course have to install it.
+- Comparing a `fauxdoc.dtrange.DateOrTimeRange` instance to another type of object is explicitly not supported and returns `NotImplemented`.
 - On `fauxdoc.emitters.choice.Choice`, any sequences provided for the `weights` and `cum_weights` attributes are now cast to tuples on assignment so that they are immutable once assigned. (You can set a brand new sequence, but you cannot change individual elements.)
 - `fauxdoc.emitters.fromfields.BasedOnFields` no longer inherits from `fauxdoc.emitters.fromfields.CopyFields`. The shared functionality that `CopyFields` previously provided is now implemented as `fauxdoc.emitters.fromfields.SourceFieldGroup`, which is now used for the `source` attribute on instances of both classes. If you set `source` directly, you must now give it a `SourceFieldGroup` instance.
 - `fauxdoc.emitters.fromfields.BasedOnFields` now uses the `fauxdoc.emitters.wrappers.BoundWrapper` class for its `action` attribute. This moves all of the relevant functionality that was basically duplicated from the `wrappers` emitters out into the `BoundWrapper`. If you set `action` directly, you must now give it a `BoundWrapper` instance.
@@ -59,7 +60,6 @@ Overview of what's new in this version:
 - The `fauxdoc.typing.EmitterLike` protocol is now more robust. It's now generic, so you can for instance use `EmitterLike[int]` to indicate that an Emitter-like type emits `int`s. It now includes properties `num_unique_values` and `emits_unique_values`. And `__call__` is overloaded to show that passing None returns a single atomic value, while passing an integer returns a list of values.
 - The `fauxdoc.typing.RandomEmitterLike` protocol now inherits from both `ImplementsRNG` and `EmitterLike`, and it is now generic.
 - The `fauxdoc.typing.FieldLike` protocol is now generic.
-- Comparing a `fauxdoc.dtrange.DateOrTimeRange` instance to another type of object is explicitly not supported and returns `NotImplemented`.
 
 ### Deprecated
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,9 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://github.com/unt-libraries/fauxdoc"
-repository = "https://github.com/unt-libraries/fauxdoc"
+Homepage = "https://github.com/unt-libraries/fauxdoc"
+Repository = "https://github.com/unt-libraries/fauxdoc"
+Changelog = "https://github.com/unt-libraries/fauxdoc/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [

--- a/src/fauxdoc/profile.py
+++ b/src/fauxdoc/profile.py
@@ -202,8 +202,8 @@ class Schema:
     """Class to define schemas, for generating full records/docs.
 
     Pass the field objects you want in your schema to __init__, add
-    them via `add_fields`, or modify `fields` directly. Call the object
-    to generate the next record.
+    them via `add_fields`, or set them via `set_fields`. Call the
+    Schema instance to generate the next record.
 
     Attributes:
         fields: An ObjectMap that maps field names (field.name) to
@@ -227,18 +227,30 @@ class Schema:
                 args. The `fields` attribute is generated from this.
                 Your field names become keys.
         """
-        self.add_fields(*fields, reset=True)
+        self.set_fields(*fields)
 
-    def add_fields(self, *fields: FieldLike[Any], reset: bool = False) -> None:
-        """Adds or sets schema fields, in the order provided.
+    def set_fields(self, *fields: FieldLike[Any]) -> None:
+        """Sets `fields` from the given Field instances.
+
+        This is a convenience method for setting the `fields`
+        attribute, which is an ObjectMap instance, from one or more
+        given Field instances. (You can still set `fields` directly by
+        passing an ObjectMap.)
 
         Args:
             *fields: The Field instances to add. Note this is a star
                 argument, so provide your fields as args.
-            reset: If True, existing fields will be overwritten.
         """
-        if reset:
-            self.fields: ObjectMap[FieldLike[Any]] = ObjectMap({})
+        self.fields: ObjectMap[FieldLike[Any]] = ObjectMap({})
+        self.add_fields(*fields)
+
+    def add_fields(self, *fields: FieldLike[Any]) -> None:
+        """Adds schema fields, in the order provided.
+
+        Args:
+            *fields: The Field instances to add. Note this is a star
+                argument, so provide your fields as args.
+        """
         self.fields.update({field.name: field for field in fields})
 
     @property

--- a/tests/test_emitters_choice.py
+++ b/tests/test_emitters_choice.py
@@ -9,55 +9,64 @@ from fauxdoc.emitters.choice import chance, Choice, gaussian_choice,\
                                     poisson_choice
 
 
-@pytest.mark.parametrize('seed, items, weights, repl, num, repeat, expected', [
-    (999, range(2), None, True, 10, 0, [1, 0, 1, 1, 0, 0, 1, 0, 1, 1]),
-    (999, range(2), None, True, None, 10, [0, 1, 1, 0, 1, 0, 0, 0, 1, 0]),
-    (999, range(1, 2), None, True, 10, 0, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
-    (999, range(1, 2), None, True, None, 10, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
-    (999, range(5, 6), None, True, 10, 0, [5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
-    (999, range(1, 11), None, True, 10, 0, [8, 1, 9, 6, 5, 2, 8, 4, 8, 9]),
-    (999, 'abcde', None, True, 10, 0,
+@pytest.mark.parametrize('seed, items, weights, cw, repl, num, repeat, exp', [
+    (999, range(2), None, None, True, 10, 0, [1, 0, 1, 1, 0, 0, 1, 0, 1, 1]),
+    (999, range(2), None, None, True, None, 10,
+     [0, 1, 1, 0, 1, 0, 0, 0, 1, 0]),
+    (999, range(1, 2), None, None, True, 10, 0,
+     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    (999, range(1, 2), None, None, True, None, 10,
+     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+    (999, range(5, 6), None, None, True, 10, 0,
+     [5, 5, 5, 5, 5, 5, 5, 5, 5, 5]),
+    (999, range(1, 11), None, None, True, 10, 0,
+     [8, 1, 9, 6, 5, 2, 8, 4, 8, 9]),
+    (999, 'abcde', None, None, True, 10, 0,
      ['d', 'a', 'e', 'c', 'c', 'a', 'd', 'b', 'd', 'e']),
-    (999, ['H', 'T'], [80, 20], True, 10, 0,
+    (999, ['H', 'T'], [80, 20], None, True, 10, 0,
      ['H', 'H', 'T', 'H', 'H', 'H', 'H', 'H', 'H', 'T']),
-    (999, ['H', 'T'], [80, 20], True, None, 10,
+    (999, ['H', 'T'], None, [80, 100], True, 10, 0,
      ['H', 'H', 'T', 'H', 'H', 'H', 'H', 'H', 'H', 'T']),
-    (999, ['H', 'T'], [20, 80], True, 10, 0,
+    (999, ['H', 'T'], [80, 20], None, True, None, 10,
+     ['H', 'H', 'T', 'H', 'H', 'H', 'H', 'H', 'H', 'T']),
+    (999, ['H', 'T'], [20, 80], None, True, 10, 0,
      ['T', 'H', 'T', 'T', 'T', 'H', 'T', 'T', 'T', 'T']),
-    (999, 'TTHHHHHHHH', None, 'after_call', 10, 0,
+    (999, ['H', 'T'], None, [20, 100], True, 10, 0,
+     ['T', 'H', 'T', 'T', 'T', 'H', 'T', 'T', 'T', 'T']),
+    (999, 'TTHHHHHHHH', None, None, 'after_call', 10, 0,
      ['T', 'H', 'H', 'H', 'H', 'H', 'T', 'H', 'H', 'H']),
-    (999, 'HHHHT', None, 'after_call', None, 10,
+    (999, 'HHHHT', None, None, 'after_call', None, 10,
      ['H', 'T', 'T', 'T', 'H', 'H', 'H', 'H', 'H', 'H']),
-    (999, 'HT', [80, 20], 'after_call', None, 10,
+    (999, 'HT', [80, 20], None, 'after_call', None, 10,
      ['H', 'H', 'T', 'H', 'H', 'H', 'H', 'H', 'H', 'T']),
-    (999, 'HT', [20, 80], 'after_call', None, 10,
+    (999, 'HT', [20, 80], None, 'after_call', None, 10,
      ['T', 'H', 'T', 'T', 'T', 'H', 'T', 'T', 'T', 'T']),
-    (999, range(5), [70, 20, 7, 2, 1], 'after_call', 3, 10,
+    (999, range(5), [70, 20, 7, 2, 1], None, 'after_call', 3, 10,
      [[0, 2, 1], [1, 0, 3], [1, 0, 2], [0, 3, 2], [0, 4, 1], [0, 2, 1],
       [1, 0, 2], [1, 0, 2], [1, 0, 3], [0, 2, 1]]),
-    (999, range(5), [70, 20, 7, 2, 1], True, 3, 10,
+    (999, range(5), [70, 20, 7, 2, 1], None, True, 3, 10,
      [[1, 0, 1], [0, 0, 0], [1, 0, 1], [1, 0, 4], [0, 0, 0], [1, 0, 1],
       [3, 0, 0], [0, 0, 0], [2, 0, 0], [0, 0, 1]]),
-    (999, range(25), None, False, 5, 5,
+    (999, range(25), None, None, False, 5, 5,
      [[11, 18, 24, 17, 2], [9, 6, 8, 0, 15], [20, 3, 14, 4, 7],
       [13, 16, 19, 23, 12], [5, 10, 1, 21, 22]]),
-    (999, range(25), None, False, None, 25,
+    (999, range(25), None, None, False, None, 25,
      [11, 18, 24, 17, 2, 9, 6, 8, 0, 15, 20, 3, 14, 4, 7, 13, 16, 19, 23, 12,
       5, 10, 1, 21, 22]),
-    (9999, range(25), [50] * 5 + [10] * 5 + [1] * 15, False, 5, 5,
+    (9999, range(25), [50] * 5 + [10] * 5 + [1] * 15, None, False, 5, 5,
      [[0, 3, 7, 12, 4], [6, 1, 2, 9, 8], [22, 14, 5, 18, 11],
       [20, 24, 13, 23, 16], [21, 17, 19, 15, 10]]),
-    (9999, range(25), [50] * 5 + [10] * 5 + [1] * 15, False, None, 25,
+    (9999, range(25), [50] * 5 + [10] * 5 + [1] * 15, None, False, None, 25,
      [0, 3, 7, 12, 4, 6, 1, 2, 9, 8, 22, 14, 5, 18, 11, 20, 24, 13, 23, 16, 21,
       17, 19, 15, 10]),
 ])
-def test_choice(seed, items, weights, repl, num, repeat, expected):
+def test_choice(seed, items, weights, cw, repl, num, repeat, exp):
     after_call = repl == 'after_call'
     replace = repl or after_call
-    ce = Choice(items, weights=weights, replace=replace,
+    ce = Choice(items, weights=weights, cum_weights=cw, replace=replace,
                 replace_only_after_call=after_call, rng_seed=seed)
     result = [ce(num) for _ in range(repeat)] if repeat else ce(num)
-    assert result == expected
+    assert result == exp
 
 
 @pytest.mark.parametrize(
@@ -199,19 +208,41 @@ def test_choice_numuniqueitems_is_readonly():
 
 
 def test_choice_weights_is_immutable():
-    ce = Choice(range(4), weights=[97, 1, 1, 1], replace=True, rng_seed=999)
+    ce = Choice(range(4), weights=[97, 1, 1, 1])
     assert ce.weights == (97, 1, 1, 1)
     with pytest.raises(TypeError):
         ce.weights[0] = 1
 
 
-def test_choice_cumweights_is_readonly_and_immutable():
-    ce = Choice(range(4), weights=[97, 1, 1, 1], replace=True, rng_seed=999)
+def test_choice_cumweights_is_immutable():
+    ce = Choice(range(4), cum_weights=[97, 98, 99, 100])
     assert ce.cum_weights == (97, 98, 99, 100)
-    with pytest.raises(AttributeError):
-        ce.cum_weights = [1, 2, 3, 4]
     with pytest.raises(TypeError):
         ce.cum_weights[0] = 1
+
+
+def test_choice_setting_weights_sets_cumweights():
+    ce = Choice(range(4))
+    ce.weights = [97, 1, 1, 1]
+    assert ce.cum_weights == (97, 98, 99, 100)
+
+
+def test_choice_setting_cumweights_sets_weights():
+    ce = Choice(range(4))
+    ce.cum_weights = [97, 98, 99, 100]
+    assert ce.weights == (97, 1, 1, 1)
+
+
+def test_choice_removing_weights_removes_cumweights():
+    ce = Choice(range(4), weights=[97, 1, 1, 1])
+    ce.weights = None
+    assert ce.cum_weights is None
+
+
+def test_choice_removing_cumweights_removes_weights():
+    ce = Choice(range(4), weights=[97, 1, 1, 1])
+    ce.cum_weights = None
+    assert ce.weights is None
 
 
 def test_choice_remove_weights_with_replacement():
@@ -427,33 +458,53 @@ def test_choice_change_replacement__none_to_replace_only_after_call():
         ce(5)
 
 
-def test_choice_empty_items():
+def test_choice_cannot_init_empty_items():
     with pytest.raises(ValueError):
         Choice(range(0))
 
 
-@pytest.mark.parametrize('items, bad_weights, noun', [
-    ([0, 1, 2, 3], [40, 50], 'item'),
-    ([0, 1], [50, 10, 2], None)
+def test_choice_cannot_init_weights_and_cumweights():
+    with pytest.raises(TypeError) as excinfo:
+        Choice(['abc'], weights=[10, 50, 40], cum_weights=[10, 60, 100])
+    assert "Only one of 'weights' or 'cum_weights'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize('items, bad_weights, are_cumulative, noun', [
+    ([0, 1, 2, 3], [40, 50], False, 'item'),
+    ([0, 1, 2, 3], [40, 50], True, 'item'),
+    ([0, 1], [50, 10, 2], False, None),
+    ([0, 1], [50, 10, 2], True, None)
 ])
-def test_choice_incorrect_weights(items, bad_weights, noun):
+def test_choice_incorrect_weights(items, bad_weights, are_cumulative, noun):
+    kwargs = {
+        'cum_weights' if are_cumulative else 'weights': bad_weights,
+        'noun': noun
+    }
     with pytest.raises(ValueError) as excinfo:
-        Choice(items, weights=bad_weights, noun=noun)
+        Choice(items, **kwargs)
     error_msg = str(excinfo.value)
     assert f"({len(items)}" in error_msg
     assert f"({len(bad_weights)}" in error_msg
     if noun:
         assert f"{noun} choices" in error_msg
+    if are_cumulative:
+        assert "choice cum_weights" in error_msg
+    else:
+        assert "choice weights" in error_msg
 
 
-@pytest.mark.parametrize('items, bad_weights', [
-    ([0, 1, 2, 3], [40, 50]),
-    ([0, 1], [50, 10, 2])
+@pytest.mark.parametrize('items, bad_weights, are_cumulative', [
+    ([0, 1, 2, 3], [40, 50], False),
+    ([0, 1, 2, 3], [40, 50], True),
+    ([0, 1], [50, 10, 2], False),
+    ([0, 1], [50, 10, 2], True),
 ])
-def test_choice_change_weights_to_incorrect_weights(items, bad_weights):
-    ce = Choice(items, weights=[10] * len(items))
+def test_choice_change_weights_to_incorrect_weights(items, bad_weights,
+                                                    are_cumulative):
+    attr = 'cum_weights' if are_cumulative else 'weights'
+    ce = Choice(items, **{attr: [10] * len(items)})
     with pytest.raises(ValueError) as excinfo:
-        ce.weights = bad_weights
+        setattr(ce, attr, bad_weights)
     error_msg = str(excinfo.value)
     assert f"({len(items)}" in error_msg
     assert f"({len(bad_weights)}" in error_msg

--- a/tests/test_emitters_wrappers.py
+++ b/tests/test_emitters_wrappers.py
@@ -193,7 +193,7 @@ def test_wrapone_wrapper_is_settable():
     em = Static(1)
     wrapped_em = WrapOne(em, lambda val: None)
     wrapped_em()
-    wrapped_em.wrapper = lambda val: f'{val}'
+    wrapped_em.wrapper = BoundWrapper(lambda val: f'{val}', wrapped_em)
     assert wrapped_em() == '1'
     assert wrapped_em.wrapper.bound_to == wrapped_em
 
@@ -202,7 +202,16 @@ def test_wrapone_setting_wrapper_w_invalid_callable_raises_error():
     em = Static(1)
     wrapped_em = WrapOne(em, lambda val: None)
     with pytest.raises(TypeError):
-        wrapped_em.wrapper = lambda val1, val2: f'{val1} {val2}'
+        wrapped_em.wrapper = BoundWrapper(lambda val1, val2: f'{val1} {val2}',
+                                          wrapped_em)
+
+
+def test_wrapone_setwrapperfunction():
+    em = Static(1)
+    wrapped_em = WrapOne(em, lambda val: None)
+    wrapped_em.set_wrapper_function(lambda val: 'new function')
+    assert isinstance(wrapped_em.wrapper, BoundWrapper)
+    assert wrapped_em.wrapper(None) == 'new function'
 
 
 @pytest.mark.parametrize('sources, wrapper, expected', [
@@ -285,7 +294,8 @@ def test_wrapmany_wrapper_is_settable():
     ems = {'one': Static(1), 'two': Static(2)}
     wrapped_em = WrapMany(ems, lambda one, two: None)
     wrapped_em()
-    wrapped_em.wrapper = lambda one, two: f'{one} {two}'
+    wrapped_em.wrapper = BoundWrapper(lambda one, two: f'{one} {two}',
+                                      wrapped_em)
     assert wrapped_em() == '1 2'
     assert wrapped_em.wrapper.bound_to == wrapped_em
 
@@ -294,4 +304,15 @@ def test_wrapmany_setting_wrapper_w_invalid_callable_raises_error():
     ems = {'one': Static(1), 'two': Static(2)}
     wrapped_em = WrapMany(ems, lambda one, two: None)
     with pytest.raises(TypeError):
-        wrapped_em.wrapper = lambda val1, val2, val3: f'{val1} {val2} {val3}'
+        wrapped_em.wrapper = BoundWrapper(
+            lambda val1, val2, val3: f'{val1} {val2} {val3}',
+            wrapped_em
+        )
+
+
+def test_wrapmany_setwrapperfunction():
+    ems = {'one': Static(1), 'two': Static(2)}
+    wrapped_em = WrapMany(ems, lambda one, two: None)
+    wrapped_em.set_wrapper_function(lambda one, two: 'new function')
+    assert isinstance(wrapped_em.wrapper, BoundWrapper)
+    assert wrapped_em.wrapper(None, None) == 'new function'

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -548,17 +548,16 @@ def test_schema_can_set_fields_directly():
     }
 
 
-def test_schema_addfields_can_set_fields():
+def test_schema_setfields():
     test_schema = Schema(
         Field('one', Static(1)),
         Field('two', Static(2)),
         Field('three', Static(3), hide=True)
     )
-    test_schema.add_fields(
+    test_schema.set_fields(
         Field('a', Static('a')),
         Field('b', Static('b'), hide=True),
-        Field('c', Static('c')),
-        reset=True
+        Field('c', Static('c'))
     )
     assert test_schema.public_fields == {
         'a': test_schema.fields['a'],

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -522,15 +522,16 @@ def test_schema_publicfields_cannot_be_changed():
 
 
 def test_schema_can_set_fields_directly():
+    # Schema.fields can be set directly -- but, we have to provide an
+    # ObjectMap.
     test_schema = Schema()
-    test_schema.fields = {
+    test_schema.fields = ObjectMap({
         'id': Field('id', Sequential(range(1, 10000))),
         'title': Field('title', Static('A Title')),
         'hidden1': Field('hidden1', Static('TEST'), hide=True),
         'author': Field('author', Static('An Author')),
         'hidden2': Field('hidden2', Static('TEST'), hide=True)
-    }
-    assert isinstance(test_schema.fields, ObjectMap)
+    })
     assert test_schema.public_fields == {
         'id': test_schema.fields['id'],
         'title': test_schema.fields['title'],
@@ -544,6 +545,31 @@ def test_schema_can_set_fields_directly():
         'id': 1,
         'title': 'A Title',
         'author': 'An Author'
+    }
+
+
+def test_schema_addfields_can_set_fields():
+    test_schema = Schema(
+        Field('one', Static(1)),
+        Field('two', Static(2)),
+        Field('three', Static(3), hide=True)
+    )
+    test_schema.add_fields(
+        Field('a', Static('a')),
+        Field('b', Static('b'), hide=True),
+        Field('c', Static('c')),
+        reset=True
+    )
+    assert test_schema.public_fields == {
+        'a': test_schema.fields['a'],
+        'c': test_schema.fields['c']
+    }
+    assert test_schema.hidden_fields == {
+        'b': test_schema.fields['b']
+    }
+    assert test_schema() == {
+        'a': 'a',
+        'c': 'c'
     }
 
 
@@ -576,13 +602,13 @@ def test_schema_fields_key_name_mismatch_is_fine():
     # each `field.name`. If they don't match it doesn't directly cause
     # any problems; the key value will be used in all Schema methods.
     test_schema = Schema()
-    test_schema.fields = {
+    test_schema.fields = ObjectMap({
         'id': Field('the', Sequential(range(1, 10000))),
         'title': Field('field', Static('A Title')),
         'hidden1': Field('name', Static('TEST'), hide=True),
         'author': Field('does not', Static('An Author')),
         'hidden2': Field('matter', Static('TEST'), hide=True)
-    }
+    })
     assert isinstance(test_schema.fields, ObjectMap)
     assert test_schema.public_fields == {
         'id': test_schema.fields['id'],
@@ -656,14 +682,14 @@ def test_schema_hidden_fields_are_still_evaluated():
 
 def test_schema_resetfields_resets_all_fields(emitter_unique):
     schema = Schema()
-    schema.fields = {
+    schema.fields = ObjectMap({
         'test': Field(
             'test',
             emitter_unique(),
             repeat=choice.Choice([1] * 12, replace=False),
             gate=choice.chance(1.0)
         )
-    }
+    })
     schema.add_fields(
         Field(
             'test2',
@@ -692,14 +718,14 @@ def test_schema_resetfields_resets_all_fields(emitter_unique):
 
 def test_schema_seedfields_reseeds_all_fields(emitter):
     schema = Schema()
-    schema.fields = {
+    schema.fields = ObjectMap({
         'test': Field(
             'test',
             emitter(),
             repeat=choice.Choice(range(1, 13)),
             gate=choice.chance(0.75), rng_seed=12345
         )
-    }
+    })
     schema.add_fields(
         Field(
             'test2',


### PR DESCRIPTION
The last thing to do before finally releasing v1.1.0 is to add a proper changelog, which this PR does. While compiling the changelog, I noted a handful of things that were still not quite correct or intuitive and decided to go ahead and make those changes, as well.

## Property setters that wrap the user-provided value during assignment

We have a few cases now where we want the user to be able to set an instance attribute by assigning a value using a normal, reasonable, common type — like a list, or a function — but, rather than storing the value as-is, we want to use it to instantiate a custom type that adds some custom attributes and/or methods. Originally we did this by implementing the attribute as a property with a setter. When set, the user-provided value is passed to the custom class, and the instance of the custom class is what's stored. This presents a couple of problems:

1. Type-checkers (specifically mypy) don't seem to like this. They expect the type the property returns and the type it's set with to be the same.
2. Assigning a value to an attribute looks just like assigning a value to a variable. In the latter case, the variable just stores whatever you assign it. If an attribute behaves differently, this is perhaps a bit weird and unexpected. For instance, if you assign `foo.bar = 1`, but then when you access `foo.bar` you get back `'1'` (as a string), this maybe breaks your expectations.

I've decided instead to implement a `set_` helper method for these, to help make it clearer that there's a type conversion going on. These attributes are still settable directly, but when set directly they expect the exact type (or a subtype).

For example. With a `fauxdoc.emitters.wrappers.WrapOne` instance — the `wrapper` attribute stores a `fauxdoc.emitters.wrappers.BoundWrapper` instance, but it's generally expected that the user will just provide a function. Rather than converting from a function to a `BoundWrapper` using a setter property, now there is a `set_wrapper_function` method. So:

```python
from fauxdoc.emitters import Static, WrapOne
from fauxdoc.emitters.wrappers import BoundWrapper

em = WrapOne(Static(1), lambda val: "original function")

# This is acceptable:
em.set_wrapper_function(lambda val: "new function")

# Or this is acceptable:
em.wrapper = BoundWrapper(lambda val: "new function", em)

# This WAS a shorthand way to do the above, but it's no longer acceptable:
em.wrapper = lambda val: "new function"
```

I've applied this new pattern to the following.
- `fauxdoc.emitters.fromfields.CopyFields` — the `source` attribute (now has a `set_source_fields` method).
- `fauxdoc.emitters.fromfields.BasedOnFields` — the `source` attribute (now has a `set_source_fields` method) and the `action` attribute (now has a `set_action_function` method).
- `fauxdoc.emitters.fromfields.WrapOne` — the `wrapper` attribute (now has a `set_wrapper_function` method).
- `fauxdoc.emitters.fromfields.WrapMany` — the `wrapper` attribute (now has a `set_wrapper_function` method).
- `fauxdoc.profile.Schema` — the `fields` attribute (now has a `set_fields` method).

## Users can now supply cumulative weights (`cum_weights`) to Choice emitters

Originally I had intended `Choice.cum_weights` to be a read-only attribute, calculated based on user supplied `weights`. However, the v1.0.0 API accidentally allowed this to be settable. Because of this, and because `random.choices` allows you to supply _either_ `weights` or `cum_weights`, I've fully implemented `cum_weights` as an equal alternative to `weights.`

- `cum_weights` is now an optional kwarg for `__init__`.
- If both `weights` and `cum_weights` are supplied to `__init__`, it raises a `TypeError`.
- When one gets set, the other gets updated appropriately.
- Checks and validation that were applied when setting `weights` are applied when setting `cum_weights`.
